### PR TITLE
chore(ci): fix main CI reference to downloaded pkger

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -32,11 +32,11 @@ jobs:
       - name: Unit Test
         run:  make test
         env:
-          PKGER: "./${{ steps.pkger-binaries.outputs.binary }}"
+          PKGER: "./pkger"
       - name: Template Unit Tests
         run:  make test-templates
         env:
-          PKGER: "./${{ steps.pkger-binaries.outputs.binary }}"
+          PKGER: "./pkger"
       - name: Lint
         run: make check
     outputs:


### PR DESCRIPTION
# Changes

:bug: Fixes CI on `main`. In a recent refactoring, some copy paste resulted in `./pkger` being
undefined in CI. This change fixes that.

/kind bug
 

