### PR TITLE
feat: print emit response output if it's a cloudevent

### DIFF
--- a/cloudevents/emitter.go
+++ b/cloudevents/emitter.go
@@ -51,8 +51,12 @@ func (e *Emitter) Emit(ctx context.Context, endpoint string) (err error) {
 	if err = evt.SetData(e.ContentType, e.Data); err != nil {
 		return
 	}
-	if result := c.Send(ctx, evt); cloudevents.IsUndelivered(result) {
+	event, result := c.Request(ctx, evt)
+	if !cloudevents.IsACK(result) {
 		return fmt.Errorf(result.Error())
+	}
+	if event != nil {
+		fmt.Printf("%v", event)
 	}
 	return nil
 }


### PR DESCRIPTION
# Changes
* :gift: if `func emit` gets a CloudEvent in response, print it for the user

The CloudEvent SDK will provide any event included in the response as a
return value from `Request()`. If it does, print it out. It makes the
experience nicer.

For example, if I run the default TypeScript event function locally, this
is what `kn emit...` looks like.

```
❯ ./func emit --sink local --data '{"hello": "world"}'
Context Attributes,
  specversion: 1.0
  type: echo
  source: function.eventViewer
  id: d7d81ccc-a365-4433-be6b-7edfa43ca360
  time: 2021-07-27T18:57:03.147Z
  datacontenttype: application/json; charset=utf-8
Data,
  {
    "hello": "world"
  }
```

Signed-off-by: Lance Ball <lball@redhat.com>

/kind enhancement

Fixes: https://github.com/knative-sandbox/kn-plugin-func/issues/388

**Release Note**

```release-note
When testing a function using `kn func emit`, if the endpoint responds with a CloudEvent, that event is now printed for the user.
```

