### PR TITLE
chore: add some collaborators to the OWNERS file

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -6,3 +6,8 @@ approvers:
 - matejvasek
 - zroubalik
 
+reviewers:
+- jcrossley3
+- jrangelramos
+- dsimansk
+


### PR DESCRIPTION

# Changes

Add @jcrossley3 @jrangelramos and @dsimansk as reviewers in the OWNERS file.

- Jim has made several nice contributions with the Rust templates and buildpacks, and his insight when reviewing these is very helpful!
- Jefferson has helped immensely with e2e, integration and other tests/validation
- David has been essential to our `kn` integration

Happy also to discuss adding these three as approvers as well, if that's a better course.

Signed-off-by: Lance Ball <lball@redhat.com>
