### PR TITLE
chore: removes deprecated CODEOWNERS file

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,3 +1,0 @@
-# These owners will be the default owners for everything in
-# the repo. Unless a later match takes precedence
-*       @lance @lkingland @matejvasek @zroubalik


### PR DESCRIPTION

:broom:  remove CODEOWNERS

It is my understanding that CODEOWNERS is deprecated in favor of OWNERS due to Prow integration.

/kind cleanup