### PR TITLE
build: remove pkged.go from make clean

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -77,13 +77,11 @@ pkged.go: $(TEMPLATES)
 clean: ## Remove generated artifacts such as binaries
 	rm -f $(BIN) $(BIN_WINDOWS) $(BIN_LINUX) $(BIN_DARWIN)
 	rm -f coverage.out
-	rm -f pkged.go
 
 
 #############
 ##@ Templates
 #############
-
 
 test-templates: test-go test-node test-python test-quarkus test-rust test-typescript ## Run all template tests
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

# Changes

:wastebasket:  remove `rm pkged.go` from `make clean`

This was an incorrect addition on my part.  Clearing this generated file results in overlapping the developer use cases of updating templates with that of modifying core source.   In particular, if I am modifying core source, and want to `make clean && make` for any reason, it does not feel right to have that trigger a rebuild of pkged.go.  The two development loops should be kept separate such that modifications to the core source code should not require the installation and running of pkger in any circumstance.  This should only be required if mutating embedded templates.

/kind chore