### PR TITLE
fix: use ascii chars in progress indicator on win

### DIFF
--- a/progress/progress.go
+++ b/progress/progress.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"runtime"
 	"time"
 )
 
@@ -227,6 +228,9 @@ func (b *Bar) spin(ch <-chan time.Time) {
 		"🕘 ",
 		"🕙 ",
 		"🕚 ",
+	}
+	if runtime.GOOS == "windows" {
+		spinner = []string{"|", "/", "-", "\\"}
 	}
 	idx := 0
 	for range ch {


### PR DESCRIPTION
- :bug: Fix bug of progress indicator on windows (there were troubles with unicode chars)

resolves #352 #354