### PR TITLE
docs: add section about Node.js log levels

### DIFF
--- a/docs/guides/nodejs.md
+++ b/docs/guides/nodejs.md
@@ -220,12 +220,15 @@ The function will log
 {"level":30,"time":1604511655265,"pid":3430203,"hostname":"localhost.localdomain","reqId":1,"msg":"Processing customer"}
 ```
 #### Setting the log level
-Developers can control the log level by setting
-the `FUNC_LOG_LEVEL` environment variable. The possible options for this
-adhere to the options available for [`pino`](https://getpino.io/#/docs/api?id=level-string),
+Developers can control the log level by setting the `logLevel` value in
+`func.yaml` The possible options for this adhere to the options available
+for [`pino`](https://getpino.io/#/docs/api?id=level-string),
 and may be one of 
 `'fatal'`, `'error'`, `'warn'`, `'info'`, `'debug'`, `'trace'` or `'silent'`.
-To set the environment variable, use the [`config` command](commands#config).
+
+To temporarily override this value, set the environment variable `FUNC_LOG_LEVEL`
+to one of the options listed above. To set the environment variable, use the
+[`config` command](commands#config).
 
 ### `query`
 Returns the query string for the request, if any, as key value pairs. These

--- a/docs/guides/nodejs.md
+++ b/docs/guides/nodejs.md
@@ -198,7 +198,8 @@ function developer.
 
 ### `log`
 Provides a logging object that can be used to write output to the cluster logs.
-The log adheres to the Pino logging API (https://getpino.io/#/docs/api).
+The log adheres to the Pino logging API. For detailed documentation on this
+logging instance, see the Pino API documentation (https://getpino.io/#/docs/api).
 
 #### Example
 ```js
@@ -218,6 +219,13 @@ The function will log
 ```console
 {"level":30,"time":1604511655265,"pid":3430203,"hostname":"localhost.localdomain","reqId":1,"msg":"Processing customer"}
 ```
+#### Setting the log level
+Developers can control the log level by setting
+the `FUNC_LOG_LEVEL` environment variable. The possible options for this
+adhere to the options available for [`pino`](https://getpino.io/#/docs/api?id=level-string),
+and may be one of 
+`'fatal'`, `'error'`, `'warn'`, `'info'`, `'debug'`, `'trace'` or `'silent'`.
+To set the environment variable, use the [`config` command](commands#config).
 
 ### `query`
 Returns the query string for the request, if any, as key value pairs. These


### PR DESCRIPTION
# Changes

- :book: adding some documentation around how to set logging levels in Node.js

Note that these documents will likely need to move out of this repo.

Fixes: https://github.com/knative-sandbox/kn-plugin-func/issues/328


