### PR TITLE
feat!: change `describe` command to `info`

### DIFF
--- a/client.go
+++ b/client.go
@@ -126,10 +126,10 @@ type ProgressListener interface {
 // Describer of Functions' remote deployed aspect.
 type Describer interface {
 	// Describe the running state of the service as reported by the underlyng platform.
-	Describe(ctx context.Context, name string) (description Description, err error)
+	Describe(ctx context.Context, name string) (description Info, err error)
 }
 
-type Description struct {
+type Info struct {
 	Name          string         `json:"name" yaml:"name"`
 	Image         string         `json:"image" yaml:"image"`
 	Namespace     string         `json:"namespace" yaml:"namespace"`
@@ -549,9 +549,9 @@ func (c *Client) List(ctx context.Context) ([]ListItem, error) {
 	return c.lister.List(ctx)
 }
 
-// Describe a Function.  Name takes precidence.  If no name is provided,
+// Info for a Function.  Name takes precidence.  If no name is provided,
 // the Function defined at root is used.
-func (c *Client) Describe(ctx context.Context, name, root string) (d Description, err error) {
+func (c *Client) Info(ctx context.Context, name, root string) (d Info, err error) {
 	go func() {
 		<-ctx.Done()
 		c.progressListener.Stopping()

--- a/cmd/emit.go
+++ b/cmd/emit.go
@@ -122,9 +122,9 @@ func runEmit(cmd *cobra.Command, _ []string, clientFn emitClientFn) (err error) 
 // Otherwise the value of Sink is used verbatim if defined.
 func endpoint(ctx context.Context, cfg emitConfig) (url string, err error) {
 	var (
-		f    fn.Function
-		d    fn.Describer
-		desc fn.Description
+		f fn.Function
+		d fn.Describer
+		i fn.Info
 	)
 
 	// If the special value "local" was requested,
@@ -151,18 +151,18 @@ func endpoint(ctx context.Context, cfg emitConfig) (url string, err error) {
 	}
 
 	// Get the current state of the function.
-	if desc, err = d.Describe(ctx, f.Name); err != nil {
+	if i, err = d.Describe(ctx, f.Name); err != nil {
 		return
 	}
 
 	// Probably wise to be defensive here:
-	if len(desc.Routes) == 0 {
+	if len(i.Routes) == 0 {
 		err = errors.New("function has no active routes")
 		return
 	}
 
 	// The first route should be the destination.
-	return desc.Routes[0], nil
+	return i.Routes[0], nil
 }
 
 type emitConfig struct {

--- a/docs/guides/commands.md
+++ b/docs/guides/commands.md
@@ -79,20 +79,20 @@ When run as a `kn` plugin.
 kn func deploy [-n <namespace> -p <path> -i <image> -r <registry> -b=true|false]
 ```
 
-## `describe`
+## `info`
 
 Prints the name, route and any event subscriptions for a deployed Function. The user may also specify the name of the function to describe. The namespace defaults to the value in `func.yaml` or the namespace currently active in the user's Kubernetes configuration. The namespace may be specified on the command line, and if so this will overwrite the value in `func.yaml`.
 
-Similar `kn` command: `kn service describe NAME [flags]`. This flag provides a lot of nice information not available in `func describe`, such as revisions, age, annotations and labels. This command should be renamed to make it distinct from `kn` - e.g. `func status`.
+Similar `kn` command: `kn service describe NAME [flags]`. This flag provides a lot of nice information not available in `func info`, such as revisions, age, annotations and labels.
 
 ```console
-func describe [-o <output> -n <namespace> -p <path>]
+func info [-o <output> -n <namespace> -p <path>]
 ```
 
 When run as a `kn` plugin.
 
 ```console
-kn func describe [-o <output> -n <namespace> -p <path>]
+kn func info [-o <output> -n <namespace> -p <path>]
 ```
 
 ## `list`

--- a/knative/describer.go
+++ b/knative/describer.go
@@ -31,7 +31,7 @@ func NewDescriber(namespaceOverride string) (describer *Describer, err error) {
 // restricts to label-syntax, which is thus escaped. Therefore as a knative (kube) implementation
 // detal proper full names have to be escaped on the way in and unescaped on the way out. ex:
 // www.example-site.com -> www-example--site-com
-func (d *Describer) Describe(ctx context.Context, name string) (description fn.Description, err error) {
+func (d *Describer) Describe(ctx context.Context, name string) (description fn.Info, err error) {
 
 	servingClient, err := NewServingClient(d.namespace)
 	if err != nil {

--- a/test/_e2e/cmd_describe_test.go
+++ b/test/_e2e/cmd_describe_test.go
@@ -5,10 +5,10 @@ import (
 	"testing"
 )
 
-// Describe runs `func describe' command basic test.
-func Describe(t *testing.T, knFunc *TestShellCmdRunner, project *FunctionTestProject)  {
+// Info runs `func info' command basic test.
+func Info(t *testing.T, knFunc *TestShellCmdRunner, project *FunctionTestProject) {
 
-	result := knFunc.Exec("describe", "--path", project.ProjectPath, "--output", "plain")
+	result := knFunc.Exec("info", "--path", project.ProjectPath, "--output", "plain")
 	if result.Error != nil {
 		t.Fail()
 	}
@@ -17,18 +17,18 @@ func Describe(t *testing.T, knFunc *TestShellCmdRunner, project *FunctionTestPro
 	// In case we have the route stored (i.e. by deploy command tested earlier)
 	// we compare just to verify they match
 	// otherwise we take advantage and capture the route from the output
-	routeFromDescribe := ""
+	routeFromInfo := ""
 
 	matches := regexp.MustCompile("Route (http.*)").FindStringSubmatch(result.Stdout)
 	if len(matches) > 1 {
-		routeFromDescribe = matches[1]
+		routeFromInfo = matches[1]
 	}
-	if routeFromDescribe == "" {
+	if routeFromInfo == "" {
 		t.Fatal("Function Route not present on output")
 	}
-	if project.FunctionURL != "" && project.FunctionURL != routeFromDescribe {
-		t.Fatalf("Expected Route %v but found %v", project.FunctionURL, routeFromDescribe)
+	if project.FunctionURL != "" && project.FunctionURL != routeFromInfo {
+		t.Fatalf("Expected Route %v but found %v", project.FunctionURL, routeFromInfo)
 	}
-	project.FunctionURL = routeFromDescribe
+	project.FunctionURL = routeFromInfo
 
 }

--- a/test/_e2e/e2e_functions_test.go
+++ b/test/_e2e/e2e_functions_test.go
@@ -21,7 +21,7 @@ func TestHttpFunction(t *testing.T) {
 	Deploy(t, knFunc, &project)
 	defer Delete(t, knFunc, &project)
 	ReadyCheck(t, knFunc, project)
-	Describe(t, knFunc, &project)
+	Info(t, knFunc, &project)
 	DefaultFunctionHttpTest(t, knFunc, project)
 	Update(t, knFunc, &project)
 	NewRevisionFunctionHttpTest(t, knFunc, project)
@@ -40,8 +40,7 @@ func TestCloudEventsFunction(t *testing.T) {
 	Deploy(t, knFunc, &project)
 	defer Delete(t, knFunc, &project)
 	ReadyCheck(t, knFunc, project)
-	Describe(t, knFunc, &project)
+	Info(t, knFunc, &project)
 	DefaultFunctionEventsTest(t, knFunc, project)
 
 }
-


### PR DESCRIPTION
# Changes

- :broom: Change the `describe` command to `info`

/kind enhancement

Fixes: https://github.com/knative-sandbox/kn-plugin-func/issues/337
The describe command conflicts sematically with kubectl describe.

**Release Note**

```release-note
The `describe` command has been renamed to `info` to reduce conflict with the `kubectl` and `kn` commands of the same name. The behavior is otherwise identical.
```

**Docs**

Documentation changes are included in this PR.
