### PR TITLE
Using systemctl to manage podman user owned service

### DIFF
--- a/docs/guides/podman.md
+++ b/docs/guides/podman.md
@@ -4,13 +4,13 @@ Under Linux, it is possible to use [podman](https://podman.io/) instead of [dock
 
 In order to do this you need to run `podman` as a service. You can do this with the following command.
 ```
-❯ podman system service --time=0
+❯ systemctl start --user podman.socket
 ```
-This will serve the Docker API on a UNIX socket at `/run/user/{uid}/podman/podman.sock`.
+This will serve the Docker API on a UNIX socket at `${XDG_RUNTIME_DIR}/podman/podman.sock` (on most systems that would be `/run/user/{uid}/podman/podman.sock`).
 
 Then set the environment variable `DOCKER_HOST` to the socket so `func` knows where to connect.
 ```
-❯ export DOCKER_HOST="unix:///run/user/$(id -u)/podman/podman.sock"
+❯ export DOCKER_HOST="unix://${XDG_RUNTIME_DIR}/podman/podman.sock"
 ❯ func build -v
 ```
 Now you may use `func` as usual.


### PR DESCRIPTION
Using systemctl is a better idea because users can utilize other subcommands like `status` or `stop` to further manage the podman service.

<!-- Thanks for sending a pull request! -->

# Changes

<!-- 
Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! 

- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

- :broom: Clean up commands to better follow standards and docs

<!--
In addition, categorize the changes you're making using the "/kind" Prow command, example:

/kind <kind>

Supported kinds are: api-change, bug, cleanup, deprecation, removal, documentation, enhancement, performance

-->

/kind cleanup
/kind documentation
