### PR TITLE
fix: support nested subdirs in remote templates

### DIFF
--- a/templates.go
+++ b/templates.go
@@ -194,12 +194,10 @@ func copy(src, dest string, accessor filesystem) (err error) {
 }
 
 func copyNode(src, dest string, accessor filesystem) (err error) {
-	node, err := accessor.Stat(src)
-	if err != nil {
-		return
-	}
-
-	err = os.MkdirAll(dest, node.Mode())
+	// Ideally we should use the file mode of the src node
+	// but it seems the git module is reporting directories
+	// as 0644 instead of 0755. For now, just do it this way.
+	err = os.MkdirAll(dest, 0755)
 	if err != nil {
 		return
 	}


### PR DESCRIPTION
# Changes

- :bug: explicitly set template directory file mode to 0755

For some reason when a node in the git in-memory file system is
Stat()ed, if it's a directory the mode bits are 0644 which is not
correct, and causes a failure when trying to write the templates.
This commit explicitly sets the file mode for all directories to
0755.

/kind bug
