### PR TITLE
fix: `config labels` panic

### DIFF
--- a/cmd/config_labels.go
+++ b/cmd/config_labels.go
@@ -79,6 +79,7 @@ directory or from the directory specified with --path.
 		},
 	}
 
+	configLabelsCmd.Flags().StringP("path", "p", cwd(), "Path to the project directory (Env: $FUNC_PATH)")
 	configLabelsCmd.AddCommand(configLabelsAddCmd)
 	configLabelsAddCmd.Flags().StringP("path", "p", cwd(), "Path to the project directory (Env: $FUNC_PATH)")
 	configLabelsCmd.AddCommand(configLabelsRemoveCmd)


### PR DESCRIPTION
- :bug: Fix `func config label` panic due to unregistered flag.
