### PR TITLE
feat: builders/buildpacks configured in client

### DIFF
--- a/client.go
+++ b/client.go
@@ -445,6 +445,27 @@ func (c *Client) Create(cfg Function) (err error) {
 		}
 	}
 
+	// Now that defaults are set from manifest.yaml for builders/buildpacks
+	// be sure to allow configuration to override these
+
+	// If buildpacks are provided, use them
+	if len(cfg.Buildpacks) > 0 {
+		f.Buildpacks = cfg.Buildpacks
+	}
+
+	// If builders are provided use them
+	if len(cfg.Builders) > 0 {
+		f.Builders = cfg.Builders
+		if f.Builders["default"] != "" {
+			f.Builder = f.Builders["default"]
+		}
+	}
+
+	// If a default builder is provided use it
+	if cfg.Builder != "" {
+		f.Builder = cfg.Builder
+	}
+
 	// Write out the config.
 	if err = writeConfig(f); err != nil {
 		return

--- a/client.go
+++ b/client.go
@@ -426,15 +426,6 @@ func (c *Client) Create(cfg Function) (err error) {
 			f.Builders = manifest.Builders
 			f.Buildpacks = manifest.Buildpacks
 			f.HealthEndpoints = manifest.HealthEndpoints
-			if c.verbose {
-				fmt.Printf("Builder:       %s\n", f.Builder)
-				if len(f.Buildpacks) > 0 {
-					fmt.Println("Buildpacks:")
-					for _, b := range f.Buildpacks {
-						fmt.Printf("           ... %s\n", b)
-					}
-				}
-			}
 		}
 		// Remove the manifest.yaml file so the user is not confused by a
 		// configuration file that is only used for project creation/initialization
@@ -464,6 +455,16 @@ func (c *Client) Create(cfg Function) (err error) {
 	// If a default builder is provided use it
 	if cfg.Builder != "" {
 		f.Builder = cfg.Builder
+	}
+
+	if c.verbose {
+		fmt.Printf("Builder:       %s\n", f.Builder)
+		if len(f.Buildpacks) > 0 {
+			fmt.Println("Buildpacks:")
+			for _, b := range f.Buildpacks {
+				fmt.Printf("           ... %s\n", b)
+			}
+		}
 	}
 
 	// Write out the config.

--- a/client_test.go
+++ b/client_test.go
@@ -9,6 +9,7 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
+	"reflect"
 	"testing"
 
 	fn "knative.dev/kn-plugin-func"
@@ -743,13 +744,13 @@ func TestWithConfiguredBuilders(t *testing.T) {
 	root := "testdata/example.com/testConfiguredBuilders" // Root from which to run the test
 	defer using(t, root)()
 
-	fxt := map[string]string{
+	builders := map[string]string{
 		"custom": "docker.io/example/custom",
 	}
 	client := fn.New(fn.WithRegistry(TestRegistry))
 	if err := client.Create(fn.Function{
 		Root:     root,
-		Builders: fxt,
+		Builders: builders,
 	}); err != nil {
 		t.Fatal(err)
 	}
@@ -759,8 +760,8 @@ func TestWithConfiguredBuilders(t *testing.T) {
 	}
 
 	// Assert that our custom builder array was set
-	if f.Builders["custom"] != fxt["custom"] {
-		t.Fatalf("Expected %s but got %s", fxt["custom"], f.Builders["custom"])
+	if !reflect.DeepEqual(f.Builders, builders) {
+		t.Fatalf("Expected %v but got %v", builders, f.Builders)
 	}
 
 	// But that the default still exists
@@ -776,14 +777,14 @@ func TestWithConfiguredBuildersWithDefault(t *testing.T) {
 	root := "testdata/example.com/testConfiguredBuildersWithDefault" // Root from which to run the test
 	defer using(t, root)()
 
-	fxt := map[string]string{
+	builders := map[string]string{
 		"custom":  "docker.io/example/custom",
 		"default": "docker.io/example/default",
 	}
 	client := fn.New(fn.WithRegistry(TestRegistry))
 	if err := client.Create(fn.Function{
 		Root:     root,
-		Builders: fxt,
+		Builders: builders,
 	}); err != nil {
 		t.Fatal(err)
 	}
@@ -793,15 +794,13 @@ func TestWithConfiguredBuildersWithDefault(t *testing.T) {
 	}
 
 	// Assert that our custom builder array was set
-	if f.Builders["custom"] != fxt["custom"] {
-		t.Fatalf("Expected %s but got %s", fxt["custom"], f.Builders["custom"])
+	if !reflect.DeepEqual(f.Builders, builders) {
+		t.Fatalf("Expected %v but got %v", builders, f.Builders)
 	}
-	if f.Builders["default"] != fxt["default"] {
-		t.Fatalf("Expected %s but got %s", fxt["default"], f.Builders["default"])
-	}
+
 	// Asser that the default is also set
-	if f.Builder != fxt["default"] {
-		t.Fatalf("Expected %s but got %s", fxt["default"], f.Builder)
+	if f.Builder != builders["default"] {
+		t.Fatalf("Expected %s but got %s", builders["default"], f.Builder)
 	}
 }
 
@@ -811,13 +810,13 @@ func TestWithConfiguredBuildpacks(t *testing.T) {
 	root := "testdata/example.com/testConfiguredBuildpacks" // Root from which to run the test
 	defer using(t, root)()
 
-	fxt := []string{
+	buildpacks := []string{
 		"docker.io/example/custom-buildpack",
 	}
 	client := fn.New(fn.WithRegistry(TestRegistry))
 	if err := client.Create(fn.Function{
 		Root:       root,
-		Buildpacks: fxt,
+		Buildpacks: buildpacks,
 	}); err != nil {
 		t.Fatal(err)
 	}
@@ -827,8 +826,8 @@ func TestWithConfiguredBuildpacks(t *testing.T) {
 	}
 
 	// Assert that our custom buildpacks were set
-	if f.Buildpacks[0] != fxt[0] {
-		t.Fatalf("Expected %s but got %s", fxt[0], f.Buildpacks[0])
+	if !reflect.DeepEqual(f.Buildpacks, buildpacks) {
+		t.Fatalf("Expected %v but got %v", buildpacks, f.Buildpacks)
 	}
 }
 

--- a/client_test.go
+++ b/client_test.go
@@ -736,6 +736,88 @@ func TestEmit(t *testing.T) {
 	}
 }
 
+func TestWithConfiguredBuilders(t *testing.T) {
+	root := "testdata/example.com/testConfiguredBuilders" // Root from which to run the test
+	defer using(t, root)()
+
+	fxt := map[string]string{
+		"custom": "docker.io/example/custom",
+	}
+	client := fn.New(fn.WithRegistry(TestRegistry))
+	client.Create(fn.Function{
+		Root:     root,
+		Builders: fxt,
+	})
+	f, err := fn.NewFunction(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Assert that our custom builder array was set
+	if f.Builders["custom"] != fxt["custom"] {
+		t.Fatalf("Expected %s but got %s", fxt["custom"], f.Builders["custom"])
+	}
+
+	// But that the default still exists
+	if f.Builder == "" {
+		t.Fatal("Expected default builder to be set")
+	}
+}
+
+func TestWithConfiguredBuildersWithDefault(t *testing.T) {
+	root := "testdata/example.com/testConfiguredBuildersWithDefault" // Root from which to run the test
+	defer using(t, root)()
+
+	fxt := map[string]string{
+		"custom":  "docker.io/example/custom",
+		"default": "docker.io/example/default",
+	}
+	client := fn.New(fn.WithRegistry(TestRegistry))
+	client.Create(fn.Function{
+		Root:     root,
+		Builders: fxt,
+	})
+	f, err := fn.NewFunction(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Assert that our custom builder array was set
+	if f.Builders["custom"] != fxt["custom"] {
+		t.Fatalf("Expected %s but got %s", fxt["custom"], f.Builders["custom"])
+	}
+	if f.Builders["default"] != fxt["default"] {
+		t.Fatalf("Expected %s but got %s", fxt["default"], f.Builders["default"])
+	}
+	// Asser that the default is also set
+	if f.Builder != fxt["default"] {
+		t.Fatalf("Expected %s but got %s", fxt["default"], f.Builder)
+	}
+}
+
+func TestWithConfiguredBuildpacks(t *testing.T) {
+	root := "testdata/example.com/testConfiguredBuildpacks" // Root from which to run the test
+	defer using(t, root)()
+
+	fxt := []string{
+		"docker.io/example/custom-buildpack",
+	}
+	client := fn.New(fn.WithRegistry(TestRegistry))
+	client.Create(fn.Function{
+		Root:       root,
+		Buildpacks: fxt,
+	})
+	f, err := fn.NewFunction(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Assert that our custom buildpacks were set
+	if f.Buildpacks[0] != fxt[0] {
+		t.Fatalf("Expected %s but got %s", fxt[0], f.Buildpacks[0])
+	}
+}
+
 // Helpers ----
 
 // USING:  Make specified dir.  Return deferrable cleanup fn.

--- a/client_test.go
+++ b/client_test.go
@@ -712,7 +712,7 @@ func TestDeployUnbuilt(t *testing.T) {
 	}
 }
 
-// TestEmit ensures that the
+// TestEmit ensures that the client properly invokes the emitter when provided
 func TestEmit(t *testing.T) {
 	sink := "http://testy.mctestface.com"
 	emitter := mock.NewEmitter()
@@ -736,6 +736,9 @@ func TestEmit(t *testing.T) {
 	}
 }
 
+// Asserts that the client properly writes user provided Builders
+// to the Function configuration but uses internal default if
+// not provided.
 func TestWithConfiguredBuilders(t *testing.T) {
 	root := "testdata/example.com/testConfiguredBuilders" // Root from which to run the test
 	defer using(t, root)()
@@ -766,6 +769,9 @@ func TestWithConfiguredBuilders(t *testing.T) {
 	}
 }
 
+// Asserts that the client properly sets user provided Builders
+// in the Function configuration, and if one of the provided is
+// keyed as "default", this is set as the default Builder.
 func TestWithConfiguredBuildersWithDefault(t *testing.T) {
 	root := "testdata/example.com/testConfiguredBuildersWithDefault" // Root from which to run the test
 	defer using(t, root)()
@@ -799,6 +805,8 @@ func TestWithConfiguredBuildersWithDefault(t *testing.T) {
 	}
 }
 
+// Asserts that the client properly sets the Buildpacks property
+// in the Function configuration when it is provided.
 func TestWithConfiguredBuildpacks(t *testing.T) {
 	root := "testdata/example.com/testConfiguredBuildpacks" // Root from which to run the test
 	defer using(t, root)()

--- a/client_test.go
+++ b/client_test.go
@@ -744,10 +744,12 @@ func TestWithConfiguredBuilders(t *testing.T) {
 		"custom": "docker.io/example/custom",
 	}
 	client := fn.New(fn.WithRegistry(TestRegistry))
-	client.Create(fn.Function{
+	if err := client.Create(fn.Function{
 		Root:     root,
 		Builders: fxt,
-	})
+	}); err != nil {
+		t.Fatal(err)
+	}
 	f, err := fn.NewFunction(root)
 	if err != nil {
 		t.Fatal(err)
@@ -773,10 +775,12 @@ func TestWithConfiguredBuildersWithDefault(t *testing.T) {
 		"default": "docker.io/example/default",
 	}
 	client := fn.New(fn.WithRegistry(TestRegistry))
-	client.Create(fn.Function{
+	if err := client.Create(fn.Function{
 		Root:     root,
 		Builders: fxt,
-	})
+	}); err != nil {
+		t.Fatal(err)
+	}
 	f, err := fn.NewFunction(root)
 	if err != nil {
 		t.Fatal(err)
@@ -803,10 +807,12 @@ func TestWithConfiguredBuildpacks(t *testing.T) {
 		"docker.io/example/custom-buildpack",
 	}
 	client := fn.New(fn.WithRegistry(TestRegistry))
-	client.Create(fn.Function{
+	if err := client.Create(fn.Function{
 		Root:       root,
 		Buildpacks: fxt,
-	})
+	}); err != nil {
+		t.Fatal(err)
+	}
 	f, err := fn.NewFunction(root)
 	if err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
 # Changes

- :gift: Recognize Builders, Builder and Buildpack in Client API function configuration when creating a new project

We have provided support for modifiying the builders and buildpacksin `func.yaml` but until now there has not been a way to set these values when creating a new function with `client.Create(cfg)`. Any values provided in `cfg` for the builders and buildpacks were ignored and the builtin defaults were used.

/kind enhancement

