### PR TITLE
fix: control chars on progress listener for Windows OS

### DIFF
--- a/client.go
+++ b/client.go
@@ -10,6 +10,7 @@ import (
 	"path/filepath"
 	"sort"
 	"sync"
+	"runtime"
 
 	"gopkg.in/yaml.v2"
 )
@@ -504,6 +505,9 @@ func (c *Client) Build(ctx context.Context, path string) (err error) {
 	// TODO: create a statu structure and return it here for optional
 	// use by the cli for user echo (rather than rely on verbose mode here)
 	message := fmt.Sprintf("🙌 Function image built: %v", f.Image)
+	if runtime.GOOS == "windows" {
+		message = fmt.Sprintf("Function image built: %v", f.Image)
+	}
 	c.progressListener.Increment(message)
 
 	return
@@ -512,7 +516,7 @@ func (c *Client) Build(ctx context.Context, path string) (err error) {
 // Deploy the Function at path.  Errors if the Function has not been
 // initialized with an image tag.
 func (c *Client) Deploy(ctx context.Context, path string) (err error) {
-	c.progressListener.Increment("Deployin function")
+	c.progressListener.Increment("Deploying function")
 	go func() {
 		<-ctx.Done()
 		c.progressListener.Stopping()

--- a/progress/progress.go
+++ b/progress/progress.go
@@ -197,7 +197,11 @@ func (b *Bar) overwrite(prefix string) {
 	//  3 Clear to the end of the line
 	//  4 Print status text with optional prefix (spinner)
 	//  5 Print linebreak such that subsequent messages print correctly.
-	fmt.Fprintf(b.out, "\r%v%v%v%v\n", up, clear, prefix, b)
+	if runtime.GOOS == "windows" {
+		fmt.Fprintf(b.out, "\r%v%v\n", prefix, b)
+	} else {
+		fmt.Fprintf(b.out, "\r%v%v%v%v\n", up, clear, prefix, b)
+	}
 }
 
 func (b *Bar) String() string {
@@ -237,7 +241,11 @@ func (b *Bar) spin(ch <-chan time.Time) {
 		// Writes the spinner frame at the beginning of the previous line, moving
 		// the cursor back to the beginning of the current line for any errors or
 		// informative messages.
-		fmt.Fprintf(b.out, "\r%v%v%v\r", up, spinner[idx], down)
+		if runtime.GOOS == "windows" {
+			fmt.Fprintf(b.out, "\r%v\r", spinner[idx])
+		} else {
+			fmt.Fprintf(b.out, "\r%v%v%v\r", up, spinner[idx], down)
+		}
 		idx = (idx + 1) % len(spinner)
 	}
 }


### PR DESCRIPTION
# Changes

- :broom: Cleaning spinner for build and deploy commands for Windows platform

/kind cleanup

Fixes #352 
