### PR TITLE
test: adding e2e test for remote repository

### DIFF
--- a/test/_e2e/cmd_build_test.go
+++ b/test/_e2e/cmd_build_test.go
@@ -1,0 +1,26 @@
+package e2e
+
+import (
+	"regexp"
+	"testing"
+)
+
+// Build runs `func build' command for a given test project.
+func Build(t *testing.T, knFunc *TestShellCmdRunner, project *FunctionTestProject)  {
+
+	result := knFunc.Exec("build", "--path", project.ProjectPath, "--registry", GetRegistry())
+	if result.Error != nil {
+		t.Fail()
+	}
+
+	// Remove some unwanted control chars to make easy to parse the result
+	cleanStdout := CleanOutput(result.Stdout)
+
+	// Build command displays a succeed message followed by the image name derived
+	wasBuilt := regexp.MustCompile("Function image built:").MatchString(cleanStdout)
+	if !wasBuilt {
+		t.Fatal("Function was not built")
+	}
+	project.IsBuilt = true
+
+}

--- a/test/_e2e/cmd_deploy_test.go
+++ b/test/_e2e/cmd_deploy_test.go
@@ -10,7 +10,12 @@ import (
 // and store on test project, so it can be used later by any another test
 func Deploy(t *testing.T, knFunc *TestShellCmdRunner, project *FunctionTestProject)  {
 
-	result := knFunc.Exec("deploy", "--path", project.ProjectPath, "--registry", GetRegistry())
+	var result TestShellCmdResult
+	if project.IsBuilt {
+		result = knFunc.Exec("deploy", "--path", project.ProjectPath, "--registry", GetRegistry(), "--build=false")
+	} else {
+		result = knFunc.Exec("deploy", "--path", project.ProjectPath, "--registry", GetRegistry())
+	}
 	if result.Error != nil {
 		t.Fail()
 	}

--- a/test/_e2e/config.go
+++ b/test/_e2e/config.go
@@ -8,8 +8,8 @@ import (
 // Intended to provide setup configuration for E2E tests
 const (
 	defaultRegistry = "localhost:5000/user"
+	testTemplateRepository = "http://github.com/boson-project/test-templates.git" //nolint:varcheck,deadcode
 )
-
 
 // GetRegistry returns registry
 func GetRegistry() string {

--- a/test/_e2e/e2e_remote_repository_test.go
+++ b/test/_e2e/e2e_remote_repository_test.go
@@ -1,0 +1,40 @@
+// +build e2e
+
+package e2e
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestRemoteRepository verifies function created using an
+// external template from a git repository
+func TestRemoteRepository(t *testing.T) {
+
+	knFunc := NewKnFuncShellCli(t)
+
+	project := FunctionTestProject{}
+	project.Runtime = "go"
+	project.Template = "e2e"
+	project.FunctionName = "func-remote-repo"
+	project.ProjectPath = filepath.Join(os.TempDir(), project.FunctionName)
+
+	result := knFunc.Exec("create", project.ProjectPath,
+		"--runtime", project.Runtime,
+		"--template", project.Template,
+		"--repository", testTemplateRepository)
+	if result.Error != nil {
+		t.Fatal()
+	}
+	defer project.RemoveProjectFolder()
+
+	Build(t, knFunc, &project)
+	Deploy(t, knFunc, &project)
+	defer Delete(t, knFunc, &project)
+	ReadyCheck(t, knFunc, project)
+
+	functionRespValidator := FunctionHttpResponsivenessValidator{ runtime: "go", targetUrl: "%v", expects: "REMOTE_VALID" }
+	functionRespValidator.Validate(t, project)
+
+}

--- a/test/_e2e/func_test_proj.go
+++ b/test/_e2e/func_test_proj.go
@@ -20,6 +20,8 @@ type FunctionTestProject struct {
 	Runtime string
 	// Function Template. Example "http"
 	Template string
+	// Indicates function is already built
+	IsBuilt bool
 	// Indicates function is already deployed
 	IsDeployed bool
 	// Indicates new revision deployed (custom template)


### PR DESCRIPTION
# Changes

- :broom: Additional e2e test for remote repository

Added a scenario for extended tests that creates and deploy a function initiated from a remote repository (in this case https://github.com/boson-project/test-templates)
 
