### PR TITLE
chore: example message changes between standalone and plugin

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -41,19 +41,19 @@ var root = &cobra.Command{
 	Long: `Serverless functions
 
 Create, build and deploy functions in serverless containers for multiple runtimes on Knative`,
-	Example: replaceNameInTemplate("func"),
+	Example: replaceNameInTemplate("func", "example"),
 }
 
-func replaceNameInTemplate(name string) string {
+func replaceNameInTemplate(name, template string) string {
 	var buffer bytes.Buffer
-	exampleTemplate.Execute(&buffer, name)
+	exampleTemplate.ExecuteTemplate(&buffer, template, name)
 	return buffer.String()
 }
 
 // NewRootCmd is used to initialize func as kn plugin
 func NewRootCmd() *cobra.Command {
 	root.Use = "kn func"
-	root.Example = replaceNameInTemplate("kn func")
+	root.Example = replaceNameInTemplate("kn func", "example")
 	return root
 }
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -41,20 +41,34 @@ var root = &cobra.Command{
 	Long: `Serverless functions
 
 Create, build and deploy functions in serverless containers for multiple runtimes on Knative`,
-	Example: replaceNameInTemplate("func", "example"),
 }
 
-func replaceNameInTemplate(name, template string) string {
+func init() {
+	var err error
+	root.Example, err = replaceNameInTemplate("func", "example")
+	if err != nil {
+		root.Example = "Usage could not be loaded"
+	}
+}
+
+func replaceNameInTemplate(name, template string) (string, error) {
 	var buffer bytes.Buffer
-	exampleTemplate.ExecuteTemplate(&buffer, template, name)
-	return buffer.String()
+	err := exampleTemplate.ExecuteTemplate(&buffer, template, name)
+	if err != nil {
+		return "", err
+	}
+	return buffer.String(), nil
 }
 
 // NewRootCmd is used to initialize func as kn plugin
-func NewRootCmd() *cobra.Command {
+func NewRootCmd() (*cobra.Command, error) {
 	root.Use = "kn func"
-	root.Example = replaceNameInTemplate("kn func", "example")
-	return root
+	var err error
+	root.Example, err = replaceNameInTemplate("kn func", "example")
+	if err != nil {
+		root.Example = "Usage could not be loaded"
+	}
+	return root, err
 }
 
 // When the code is loaded into memory upon invocation, the cobra/viper packages

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -124,15 +124,19 @@ func Test_CMDParameterized(t *testing.T) {
 		t.Fatalf("default command use should be \"func\".")
 	}
 
-	if root.Example != replaceNameInTemplate("func", "example") {
-		t.Fatalf("default command example should assume \"func\" as executable name.")
+	usageExample, err := replaceNameInTemplate("func", "example")
+	if root.Example != usageExample || err != nil {
+		t.Fatalf("default command example should assume \"func\" as executable name. error: %v", err)
 	}
 
-	if NewRootCmd().Use != "kn func" {
+	cmd, err := NewRootCmd()
+	if cmd.Use != "kn func" && err != nil {
 		t.Fatalf("plugin command use should be \"kn func\".")
 	}
 
-	if NewRootCmd().Example != replaceNameInTemplate("kn func", "example") {
-		t.Fatalf("plugin command example should assume \"kn func\" as executable name.")
+	usageExample, _ = replaceNameInTemplate("kn func", "example")
+	cmd, err = NewRootCmd()
+	if cmd.Example != usageExample || err != nil {
+		t.Fatalf("plugin command example should assume \"kn func\" as executable name. error: %v", err)
 	}
 }

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -117,3 +117,22 @@ func Test_mergeEnvMaps(t *testing.T) {
 		})
 	}
 }
+
+func Test_CMDParameterized(t *testing.T) {
+
+	if root.Use != "func" {
+		t.Fatalf("default command use should be \"func\".")
+	}
+
+	if root.Example != replaceNameInTemplate("func") {
+		t.Fatalf("default command example should assume \"func\" as executable name.")
+	}
+
+	if NewRootCmd().Use != "kn func" {
+		t.Fatalf("plugin command use should be \"kn func\".")
+	}
+
+	if NewRootCmd().Example != replaceNameInTemplate("kn func") {
+		t.Fatalf("plugin command example should assume \"kn func\" as executable name.")
+	}
+}

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -124,7 +124,7 @@ func Test_CMDParameterized(t *testing.T) {
 		t.Fatalf("default command use should be \"func\".")
 	}
 
-	if root.Example != replaceNameInTemplate("func") {
+	if root.Example != replaceNameInTemplate("func", "example") {
 		t.Fatalf("default command example should assume \"func\" as executable name.")
 	}
 
@@ -132,7 +132,7 @@ func Test_CMDParameterized(t *testing.T) {
 		t.Fatalf("plugin command use should be \"kn func\".")
 	}
 
-	if NewRootCmd().Example != replaceNameInTemplate("kn func") {
+	if NewRootCmd().Example != replaceNameInTemplate("kn func", "example") {
 		t.Fatalf("plugin command example should assume \"kn func\" as executable name.")
 	}
 }

--- a/plugin/plugin.go
+++ b/plugin/plugin.go
@@ -59,7 +59,7 @@ func (f *funcPlugin) CommandParts() []string {
 	return []string{"func"}
 }
 
-// Path is empty because its an internal plugins
+// Path is empty because its an internal plugin
 func (f *funcPlugin) Path() string {
 	return ""
 }

--- a/plugin/plugin.go
+++ b/plugin/plugin.go
@@ -35,7 +35,7 @@ func (f *funcPlugin) Execute(args []string) error {
 		cancel()
 	}()
 
-	rootCmd := cmd.NewRootCmd()
+	rootCmd, _ := cmd.NewRootCmd()
 	info, _ := debug.ReadBuildInfo()
 	for _, dep := range info.Deps {
 		if strings.Contains(dep.Path, "boson-project/func") {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->
# Changes
- The example message changes depending on the command being executed as standalone or as a plugin for the `kn` executable

/kind enhancement

Fixes #214