### PR TITLE
ci: avert tar error in lint action

### DIFF
--- a/.github/workflows/knative-style.yaml
+++ b/.github/workflows/knative-style.yaml
@@ -128,6 +128,12 @@ jobs:
         uses: golangci/golangci-lint-action@v2
         with:
           version: v1.42
+          # tar errors extracting to pkg dir
+          # example: https://github.com/knative-sandbox/kn-plugin-func/pull/490/checks?check_run_id=3551662472
+          # issue:   https://github.com/golangci/golangci-lint-action/issues/244
+          # hotfix is to skip the pkg cache, which also requires an extended timeout:
+          skip-pkg-cache: true
+          args: --timeout=5m
 
       - name: misspell
         shell: bash


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

# Changes

- :bug: fix CI error in the Go Lint step of the Lint action.

This is a workaround to [an open issue in golangci-lint-action](https://github.com/golangci/golangci-lint-action/issues/244).

An [example of the error](https://github.com/knative-sandbox/kn-plugin-func/pull/490/checks?check_run_id=3551662472):
```
Error: /usr/bin/tar: ../../../go/pkg/mod/github.com/client9/misspell@v0.3.4/legal.go: Cannot open: File exists
Warning: Tar failed with error: The process '/usr/bin/tar' failed with exit code 2
```

/kind bug