### PR TITLE
fix: prompt default options

### DIFF
--- a/cmd/repository.go
+++ b/cmd/repository.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"errors"
 	"fmt"
 	"os"
 
@@ -522,7 +523,6 @@ func runRepositoryRename(args []string, clientFn repositoryClientFn) (err error)
 				Prompt: &survey.Select{
 					Message: "Repository to rename:",
 					Options: repositories,
-					Default: params.Old,
 				},
 			}, {
 				Name:     "New",
@@ -586,6 +586,10 @@ func runRepositoryRemove(args []string, clientFn repositoryClientFn) (err error)
 		return
 	}
 
+	if len(repositories) == 0 {
+		return errors.New("No repositories installed. use 'add' to install")
+	}
+
 	// Confirm (interactive prompt mode)
 	if cfg.Confirm && interactiveTerminal() {
 		questions := []*survey.Question{
@@ -595,7 +599,6 @@ func runRepositoryRemove(args []string, clientFn repositoryClientFn) (err error)
 				Prompt: &survey.Select{
 					Message: "Repository to remove:",
 					Options: repositories,
-					Default: params.Name,
 				},
 			}, {
 				Name: "Sure",

--- a/repositories.go
+++ b/repositories.go
@@ -1,6 +1,7 @@
 package function
 
 import (
+	"errors"
 	"io/ioutil"
 	"net/url"
 	"os"
@@ -107,6 +108,9 @@ func (r *Repositories) Rename(from, to string) error {
 // Remove a repository of the given name from the repositories.
 // (removes its directory in Path)
 func (r *Repositories) Remove(name string) error {
+	if name == "" {
+		return errors.New("name is required")
+	}
 	path := filepath.Join(r.Path, name)
 	return os.RemoveAll(path)
 }


### PR DESCRIPTION

- :bug: removal of repositories

Removes the default value from prompt options and adds a backup assertion on removal.

Works around a strange (bug?) behavior in the Prompt library where, if a default value for a set of Prompt options is set to the empty member, no value is permitted to pass through even though it is set as required _and_ the UI shows the first option as selected.  This bug is equivalent to a set of radio buttons showing in the UI the first element selected by default, but instead behaving as though no radios were selected on hitting submit (no initially selected radios).  This issue is an edge case and only seemed to rear its head when not interacting with the prompt in any way other than hitting enter for defaults.

The fix (workaround, really) is to remove the explicit setting of the default value to a member known to be empty.

/kind bug