### PR TITLE
Apply linting to all files with build tags as well

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -6,6 +6,13 @@
 #
 # 
 #
+run:
+  build-tags:
+    - e2e
+    - e2elc
+    - linux
+    - integration
+
 linters:
   enable:
     - unconvert

--- a/client_int_test.go
+++ b/client_int_test.go
@@ -326,18 +326,3 @@ func rm(t *testing.T, dir string) {
 		t.Fatal(err)
 	}
 }
-
-func touch(file string) {
-	_, err := os.Stat(file)
-	if os.IsNotExist(err) {
-		f, err := os.Create(file)
-		if err != nil {
-			panic(err)
-		}
-		defer f.Close()
-	}
-	t := time.Now().Local()
-	if err := os.Chtimes(file, t, t); err != nil {
-		panic(err)
-	}
-}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

# Changes

As per title, this lints all the test files behind build tags as well and fixes stray issues with that.