### PR TITLE
fix: hide a fmt.Println behind verbose flag

### DIFF
--- a/knative/deployer.go
+++ b/knative/deployer.go
@@ -92,7 +92,9 @@ func (d *Deployer) Deploy(ctx context.Context, f fn.Function) (result fn.Deploym
 				return fn.DeploymentResult{}, err
 			}
 
-			fmt.Println("Function deployed at URL: " + route.Status.URL.String())
+			if d.Verbose {
+				fmt.Println("Function deployed at URL: " + route.Status.URL.String())
+			}
 			return fn.DeploymentResult{
 				Status: fn.Deployed,
 				URL:    route.Status.URL.String(),


### PR DESCRIPTION
There was a `fmt.Println()` statement not wrapped by the verbose flag that resulted in deployments looking like this:

```
> kn func deploy
   Deploying function
🕕 Deploying function to the cluster
Function deployed at URL: http://tscript-default.lball-cluster-0c576f1
     Function deployed at URL: http://tscript-default.lball-cluster-0c576f1a70d464f092d8591997631748-0000.us-east.containers.appdomain.cloud
```
