### PR TITLE
fix: update-pkger.sh sed error on osX

### DIFF
--- a/hack/update-pkger.sh
+++ b/hack/update-pkger.sh
@@ -20,12 +20,10 @@ set -o pipefail
 
 source $(dirname $0)/../vendor/knative.dev/hack/library.sh
 
-# Hack: Remove the build tag before running pkger
-tools="${REPO_ROOT_DIR}/hack/tools.go"
-first="$(head -n1 "$tools")"
-sed -i '1d' "$tools"
+# Hack: touch a non-tagged file so that pkger doesn't complain
+echo -e "package tools" > "$REPO_ROOT_DIR/hack/package.go"
 
 go run ./vendor/github.com/markbates/pkger/cmd/pkger
 
-# Hack: Restore build tag.
-echo -e "$first\n$(cat "$tools")" > "$tools"
+# Hack: remove touched file.
+rm "$REPO_ROOT_DIR/hack/package.go"


### PR DESCRIPTION
The script depends on GNU-sed command syntax, which is not installed on OS X by default (OSX uses BSD).  This update changes the solution to using a touched file rather than sed. 

A concern was raised that this solution may interfere with other automated tasks, such as the license checker, so we should watch carefully and either back it out, or propose a different solution, if that does indeed happen.

/kind bug