### PR TITLE
fix: Environment values -> Environment variables

### DIFF
--- a/cmd/config.go
+++ b/cmd/config.go
@@ -75,8 +75,8 @@ func runConfigCmd(cmd *cobra.Command, args []string) (err error) {
 			Name: "selectedConfig",
 			Prompt: &survey.Select{
 				Message: "What do you want to configure?",
-				Options: []string{"Environment values", "Volumes", "Labels"},
-				Default: "Environment values",
+				Options: []string{"Environment variables", "Volumes", "Labels"},
+				Default: "Environment variables",
 			},
 		},
 		{
@@ -106,7 +106,7 @@ func runConfigCmd(cmd *cobra.Command, args []string) (err error) {
 	case "Add":
 		if answers.SelectedConfig == "Volumes" {
 			err = runAddVolumesPrompt(cmd.Context(), function)
-		} else if answers.SelectedConfig == "Environment values" {
+		} else if answers.SelectedConfig == "Environment variables" {
 			err = runAddEnvsPrompt(cmd.Context(), function)
 		} else if answers.SelectedConfig == "Labels" {
 			err = runAddLabelsPrompt(cmd.Context(), function, defaultLoaderSaver)
@@ -114,7 +114,7 @@ func runConfigCmd(cmd *cobra.Command, args []string) (err error) {
 	case "Remove":
 		if answers.SelectedConfig == "Volumes" {
 			err = runRemoveVolumesPrompt(function)
-		} else if answers.SelectedConfig == "Environment values" {
+		} else if answers.SelectedConfig == "Environment variables" {
 			err = runRemoveEnvsPrompt(function)
 		} else if answers.SelectedConfig == "Labels" {
 			err = runRemoveLabelsPrompt(function, defaultLoaderSaver)
@@ -122,7 +122,7 @@ func runConfigCmd(cmd *cobra.Command, args []string) (err error) {
 	case "List":
 		if answers.SelectedConfig == "Volumes" {
 			listVolumes(function)
-		} else if answers.SelectedConfig == "Environment values" {
+		} else if answers.SelectedConfig == "Environment variables" {
 			listEnvs(function)
 		} else if answers.SelectedConfig == "Labels" {
 			listLabels(function)


### PR DESCRIPTION
Signed-off-by: Zbynek Roubalik <zroubali@redhat.com>

<!-- Thanks for sending a pull request! -->

# Changes

fix: Environment values -> Environment variables

<!-- 
Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! 

- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

I've just recently noticed that if you run `func config` it will give you option to configure `Environment values` not `Environment variables` as it should be and it is being used in the rest of the commands. 

So fixing this typo which happened I don't know why 🤷‍♂️ 
