### PR TITLE
Do not print header when `func list` does not find any functions

### DIFF
--- a/cmd/list.go
+++ b/cmd/list.go
@@ -102,6 +102,7 @@ func runList(cmd *cobra.Command, _ []string, clientFn listClientFn) (err error) 
 		} else {
 			fmt.Println("No functions found")
 		}
+		return
 	}
 
 	write(os.Stdout, listItems(items), config.Output)


### PR DESCRIPTION
`func list` prints the header when it gets `No functions found`.
This patch stops displaying the header.

ASIS
```
$ func list
No functions found
NAME  NAMESPACE  RUNTIME  URL  READY
```

The header `NAME  NAMESPACE  RUNTIME  URL  READY` should not be printed.

TOBE (by this patch)
```
$ func list
No functions found
```

/kind cleanup