### PR TITLE
feat: function creation timestamp

### DIFF
--- a/client.go
+++ b/client.go
@@ -481,7 +481,8 @@ func (c *Client) Create(f Function) (err error) {
 		return
 	}
 
-	// Write the Function metadata (func.yaml)
+	// Mark it as having been created via this client library and Write (save)
+	f.Created = time.Now()
 	if err = writeConfig(f); err != nil {
 		return
 	}

--- a/client_test.go
+++ b/client_test.go
@@ -12,6 +12,7 @@ import (
 	"path/filepath"
 	"reflect"
 	"testing"
+	"time"
 
 	fn "knative.dev/kn-plugin-func"
 	"knative.dev/kn-plugin-func/mock"
@@ -874,6 +875,29 @@ func TestRuntimes(t *testing.T) {
 		t.Logf("expected: %v", expected)
 		t.Logf("received: %v", runtimes)
 		t.Fatal("Runtimes not as expected.")
+	}
+}
+
+// TestCreateStamp ensures that the creation timestamp is set on functions
+// which are successfully initialized using the client library.
+func TestCreateStamp(t *testing.T) {
+	root := "testdata/example.com/testCreateStamp"
+	defer using(t, root)()
+
+	start := time.Now()
+
+	client := fn.New(fn.WithRegistry(TestRegistry))
+
+	if err := client.New(context.Background(), fn.Function{Root: root}); err != nil {
+		t.Fatal(err)
+	}
+
+	f, err := fn.NewFunction(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !f.Created.After(start) {
+		t.Fatalf("expected function timestamp to be after '%v', got '%v'", start, f.Created)
 	}
 }
 

--- a/cmd/delete_test.go
+++ b/cmd/delete_test.go
@@ -63,6 +63,7 @@ builders:
 envs: []
 annotations: {}
 labels: []
+created: 2021-01-01T00:00:00+00:00
 `
 	if err := ioutil.WriteFile("func.yaml", []byte(funcYaml), 0600); err != nil {
 		t.Fatal(err)

--- a/config.go
+++ b/config.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 	"regexp"
 	"strings"
+	"time"
 
 	"gopkg.in/yaml.v2"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -146,6 +147,7 @@ type Config struct {
 	Annotations     map[string]string `yaml:"annotations"`
 	Options         Options           `yaml:"options"`
 	Labels          Labels            `yaml:"labels"`
+	Created         time.Time         `yaml:"created"`
 	// Add new values to the toConfig/fromConfig functions.
 }
 
@@ -268,6 +270,7 @@ func fromConfig(c Config) (f Function) {
 		Annotations:     c.Annotations,
 		Options:         c.Options,
 		Labels:          c.Labels,
+		Created:         c.Created,
 	}
 }
 
@@ -289,6 +292,7 @@ func toConfig(f Function) Config {
 		Annotations:     f.Annotations,
 		Options:         f.Options,
 		Labels:          f.Labels,
+		Created:         f.Created,
 	}
 }
 

--- a/function.go
+++ b/function.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"time"
 )
 
 type Function struct {
@@ -75,6 +76,11 @@ type Function struct {
 
 	// Health endpoints specified by the language pack
 	HealthEndpoints HealthEndpoints
+
+	// Created time is the moment that creation was successfully completed
+	// according to the client which is in charge of what constitutes being
+	// fully "Created" (aka initialized)
+	Created time.Time
 }
 
 // NewFunction loads a Function from a path on disk. use .Initialized() to determine if

--- a/schema/func_yaml-schema.json
+++ b/schema/func_yaml-schema.json
@@ -18,7 +18,8 @@
 				"envs",
 				"annotations",
 				"options",
-				"labels"
+				"labels",
+				"created"
 			],
 			"properties": {
 				"name": {
@@ -96,6 +97,10 @@
 						"$ref": "#/definitions/Label"
 					},
 					"type": "array"
+				},
+				"created": {
+					"type": "string",
+					"format": "date-time"
 				}
 			},
 			"additionalProperties": false,


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

# Changes

- :gift: function creation timestamp

It is becoming clear that a timestamp of when a Function successfully completed the creation process will be valuable.  In particular this will help with a few forthcoming PRs currently WIP, I'm separating this into its own PR to solicit feedback such as consequences unanticipated.