### PR TITLE
chore: build tag consistency

### DIFF
--- a/cloudevents/emitter_test.go
+++ b/cloudevents/emitter_test.go
@@ -1,3 +1,6 @@
+//go:build !integration
+// +build !integration
+
 package cloudevents
 
 import (

--- a/docker/credentials_helper_test.go
+++ b/docker/credentials_helper_test.go
@@ -1,3 +1,6 @@
+//go:build !integration
+// +build !integration
+
 package docker
 
 import "testing"

--- a/docker/pusher_test.go
+++ b/docker/pusher_test.go
@@ -1,3 +1,6 @@
+//go:build !integration
+// +build !integration
+
 package docker
 
 import (

--- a/knative/deployer_test.go
+++ b/knative/deployer_test.go
@@ -1,3 +1,6 @@
+//go:build !integration
+// +build !integration
+
 package knative
 
 import (

--- a/repository_test.go
+++ b/repository_test.go
@@ -1,3 +1,6 @@
+//go:build !integration
+// +build !integration
+
 package function_test
 
 import (


### PR DESCRIPTION
- :broom: adds missing build tag to some unit test files

The integration tests and unit tests are currently expected to be disjunct sets.  While we may change to being additive in the future, this change makes us consistent by adding the integration exclusion tag to a few non-integration test files where it was currently missing.