### PR TITLE
feat: add POD_NAME as an environment variable

### DIFF
--- a/knative/deployer.go
+++ b/knative/deployer.go
@@ -392,7 +392,14 @@ func processLabels(f fn.Function) (map[string]string, error) {
 //   - value: {{ configMap:configMapName }}      # all key-pair values from ConfigMap are set as ENV
 func processEnvs(envs []fn.Env, referencedSecrets, referencedConfigMaps *sets.String) ([]corev1.EnvVar, []corev1.EnvFromSource, error) {
 
-	envVars := []corev1.EnvVar{{Name: "BUILT", Value: time.Now().Format("20060102T150405")}}
+	envVars := []corev1.EnvVar{
+		{Name: "BUILT", Value: time.Now().Format("20060102T150405")},
+		{Name: "POD_NAME", ValueFrom: &corev1.EnvVarSource{
+			FieldRef: &corev1.ObjectFieldSelector{
+				FieldPath: "metadata.name",
+			},
+		}},
+	}
 	envFrom := []corev1.EnvFromSource{}
 
 	for _, env := range envs {

--- a/knative/deployer_test.go
+++ b/knative/deployer_test.go
@@ -11,6 +11,28 @@ import (
 	fn "knative.dev/kn-plugin-func"
 )
 
+// Tests that the deployer sets an environment variable POD_NAME
+// with a reference to the Pod's metadata using the downward API
+// https://kubernetes.io/docs/tasks/inject-data-application/environment-variable-expose-pod-information/
+func Test_setsPodNameAsEnvVar(t *testing.T) {
+	f := fn.Function{
+		Name: "testing",
+	}
+	envs, _, err := processEnvs(f.Envs, nil, nil)
+	if err != nil {
+		t.Error(err)
+	}
+	// TODO: is this too fragile, knowing that it should be
+	// the second value in the array?
+	env := envs[1]
+	if env.Name != "POD_NAME" {
+		t.Errorf("Expected 'POD_NAME' got '%s'", env.Name)
+	}
+	if env.ValueFrom.FieldRef.FieldPath != "metadata.name" {
+		t.Errorf("Expected 'metadata.name' got '%s'\n", env.ValueFrom.FieldRef.FieldPath)
+	}
+}
+
 func Test_setHealthEndpoints(t *testing.T) {
 	f := fn.Function{
 		Name: "testing",


### PR DESCRIPTION

# Changes

:gift: This change adds POD_NAME as an environment variable for a deployed
function using the Kubernetes downward API. An alternative means of exposing
this information would be through the filesystem. For example, a file at
`/etc/func/pod_name` would contain the pod's name. I chose to use the env
as the place to surface this because it was easier to implement, and likely
easier to consume for a function developer.

The motivation for this change is that the Node.js and TypeScript invocation
runtime will be exposing telemetry/metrics through Prometheus at a `/metrics`
endpoint (see: https://github.com/boson-project/faas-js-runtime/pull/109).
The OpenTelemetry specification has some experimental labels for function
runtime environments which don't specifically mention pod name (the spec
is not unique to Kubernetes), but do imply the need for a unique identifier
such as this.

Ref: https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/resource/semantic_conventions/faas.md

/kind enhancement

