### PR TITLE
Revert "feat: add POD_NAME as an environment variable (#660)"

### DIFF
--- a/knative/deployer.go
+++ b/knative/deployer.go
@@ -392,14 +392,7 @@ func processLabels(f fn.Function) (map[string]string, error) {
 //   - value: {{ configMap:configMapName }}      # all key-pair values from ConfigMap are set as ENV
 func processEnvs(envs []fn.Env, referencedSecrets, referencedConfigMaps *sets.String) ([]corev1.EnvVar, []corev1.EnvFromSource, error) {
 
-	envVars := []corev1.EnvVar{
-		{Name: "BUILT", Value: time.Now().Format("20060102T150405")},
-		{Name: "POD_NAME", ValueFrom: &corev1.EnvVarSource{
-			FieldRef: &corev1.ObjectFieldSelector{
-				FieldPath: "metadata.name",
-			},
-		}},
-	}
+	envVars := []corev1.EnvVar{{Name: "BUILT", Value: time.Now().Format("20060102T150405")}}
 	envFrom := []corev1.EnvFromSource{}
 
 	for _, env := range envs {

--- a/knative/deployer_test.go
+++ b/knative/deployer_test.go
@@ -11,28 +11,6 @@ import (
 	fn "knative.dev/kn-plugin-func"
 )
 
-// Tests that the deployer sets an environment variable POD_NAME
-// with a reference to the Pod's metadata using the downward API
-// https://kubernetes.io/docs/tasks/inject-data-application/environment-variable-expose-pod-information/
-func Test_setsPodNameAsEnvVar(t *testing.T) {
-	f := fn.Function{
-		Name: "testing",
-	}
-	envs, _, err := processEnvs(f.Envs, nil, nil)
-	if err != nil {
-		t.Error(err)
-	}
-	// TODO: is this too fragile, knowing that it should be
-	// the second value in the array?
-	env := envs[1]
-	if env.Name != "POD_NAME" {
-		t.Errorf("Expected 'POD_NAME' got '%s'", env.Name)
-	}
-	if env.ValueFrom.FieldRef.FieldPath != "metadata.name" {
-		t.Errorf("Expected 'metadata.name' got '%s'\n", env.ValueFrom.FieldRef.FieldPath)
-	}
-}
-
 func Test_setHealthEndpoints(t *testing.T) {
 	f := fn.Function{
 		Name: "testing",


### PR DESCRIPTION
This reverts commit 64473b7197bb5a821b6724a8b914784891b1a828.

The `/lgtm` arrived before integration tests completed, and unfortunately, setting this value in the container spec is prohibited by knative, it seems.

```
client_int_test.go:134: knative deployer failed to deploy the Knative Service: admission webhook "validation.webhook.serving.knative.dev" denied the request: validation failed: must not set the field(s): spec.template.spec.containers[0].env[1].valueFrom.fieldRef
```

