### PR TITLE
fix: use default socket path for TCP connections

### DIFF
--- a/docker/docker_client.go
+++ b/docker/docker_client.go
@@ -41,6 +41,14 @@ func NewClient(defaultHost string) (dockerClient client.CommonAPIClient, dockerH
 
 	_url, err = url.Parse(dockerHost)
 	isSSH := err == nil && _url.Scheme == "ssh"
+	isTCP := err == nil && _url.Scheme == "tcp"
+
+	if isTCP {
+		// With TCP, it's difficult to determine how to expose the daemon socket to lifecycle containers,
+		// so we are defaulting to standard docker location by returning empty string.
+		// This should work well most of the time.
+		dockerHost = ""
+	}
 
 	if !isSSH {
 		dockerClient, err = client.NewClientWithOpts(client.FromEnv, client.WithAPIVersionNegotiation())


### PR DESCRIPTION
# Changes

- :bug: Fix issues with TCP TLS connection.

resolves: #668