### PR TITLE
fix: schema-generate should point to `function.go`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -152,7 +152,7 @@ $(BIN_WINDOWS): pkged.go
 ##@ Schemas
 ######################
 schema-generate: schema/func_yaml-schema.json ## Generate func.yaml schema
-schema/func_yaml-schema.json: config.go
+schema/func_yaml-schema.json: function.go
 	go run schema/generator/main.go
 
 schema-check: ## Check that func.yaml schema is up-to-date


### PR DESCRIPTION
Signed-off-by: Zbynek Roubalik <zroubali@redhat.com>

<!-- Thanks for sending a pull request! -->

func.yaml config is now being generated from `function.go` and not `config.go` as it was before. Therefore we need to change the target for schema generation.
