### PR TITLE
feat: ensure config fs structure

### DIFF
--- a/client_test.go
+++ b/client_test.go
@@ -45,6 +45,35 @@ func TestNew(t *testing.T) {
 	}
 }
 
+// TestInstantiationCreatesRepositoriesPath ensures that instantiating the
+// client has the side-effect of ensuring that the repositories path exists
+// on-disk, and also confirms that the XDG_CONFIG_HOME environment variable is
+// respected when calculating this home path.
+func TestInstantiationCreatesRepositoriesPath(t *testing.T) {
+	root := "testdata/example.com/testNewCreatesRepositoriesPath"
+	defer Using(t, root)()
+
+	rootAbs, err := filepath.Abs(root) // absolute path to root
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Instruct the system to use the above test root directory as the home dir.
+	os.Setenv("XDG_CONFIG_HOME", rootAbs)
+
+	// The expected full path to the repositories should be:
+	expected := filepath.Join(rootAbs, "func", "repositories")
+
+	// Create a new client, which should perform initialization checks such as
+	// ensuring the full path to repositories exists.
+	_ = fn.New(fn.WithRegistry(TestRegistry))
+
+	// Confirm that the repositories path exists.
+	if _, err := os.Stat(expected); err != nil {
+		t.Fatal(err)
+	}
+}
+
 // TestRuntimeRequired ensures that the the runtime is an expected value.
 func TestRuntimeRequired(t *testing.T) {
 	// Create a root for the new Function

--- a/cmd/create.go
+++ b/cmd/create.go
@@ -246,7 +246,7 @@ func newCreateConfig(args []string, clientFn createClientFn) (cfg createConfig, 
 	// it is still available as an environment variable.
 	repositories = os.Getenv("FUNC_REPOSITORIES")
 	if repositories == "" { // if no env var provided
-		repositories = repositoriesPath() // use ~/.config/func/repositories
+		repositories = fn.RepositoriesPath() // use ~/.config/func/repositories
 	}
 
 	// Config is the final default values based off the execution context.

--- a/cmd/repository.go
+++ b/cmd/repository.go
@@ -169,7 +169,7 @@ EXAMPLES
 	}
 
 	cmd.Flags().BoolP("confirm", "c", false, "Prompt to confirm all options interactively (Env: $FUNC_CONFIRM)")
-	cmd.Flags().StringP("repositories", "r", repositoriesPath(), "Path to language pack repositories (Env: $FUNC_REPOSITORIES)")
+	cmd.Flags().StringP("repositories", "r", fn.RepositoriesPath(), "Path to language pack repositories (Env: $FUNC_REPOSITORIES)")
 
 	cmd.RunE = func(cmd *cobra.Command, args []string) error {
 		return runRepository(cmd, args, clientFn)
@@ -184,7 +184,7 @@ func NewRepositoryListCmd(clientFn repositoryClientFn) *cobra.Command {
 		PreRunE: bindEnv("repositories"),
 	}
 
-	cmd.Flags().StringP("repositories", "r", repositoriesPath(), "Path to language pack repositories (Env: $FUNC_REPOSITORIES)")
+	cmd.Flags().StringP("repositories", "r", fn.RepositoriesPath(), "Path to language pack repositories (Env: $FUNC_REPOSITORIES)")
 
 	cmd.RunE = func(_ *cobra.Command, args []string) error {
 		return runRepositoryList(args, clientFn)
@@ -201,7 +201,7 @@ func NewRepositoryAddCmd(clientFn repositoryClientFn) *cobra.Command {
 	}
 
 	cmd.Flags().BoolP("confirm", "c", false, "Prompt to confirm all options interactively (Env: $FUNC_CONFIRM)")
-	cmd.Flags().StringP("repositories", "r", repositoriesPath(), "Path to language pack repositories (Env: $FUNC_REPOSITORIES)")
+	cmd.Flags().StringP("repositories", "r", fn.RepositoriesPath(), "Path to language pack repositories (Env: $FUNC_REPOSITORIES)")
 
 	cmd.RunE = func(_ *cobra.Command, args []string) error {
 		return runRepositoryAdd(args, clientFn)
@@ -217,7 +217,7 @@ func NewRepositoryRenameCmd(clientFn repositoryClientFn) *cobra.Command {
 	}
 
 	cmd.Flags().BoolP("confirm", "c", false, "Prompt to confirm all options interactively (Env: $FUNC_CONFIRM)")
-	cmd.Flags().StringP("repositories", "r", repositoriesPath(), "Path to language pack repositories (Env: $FUNC_REPOSITORIES)")
+	cmd.Flags().StringP("repositories", "r", fn.RepositoriesPath(), "Path to language pack repositories (Env: $FUNC_REPOSITORIES)")
 
 	cmd.RunE = func(_ *cobra.Command, args []string) error {
 		return runRepositoryRename(args, clientFn)
@@ -235,7 +235,7 @@ func NewRepositoryRemoveCmd(clientFn repositoryClientFn) *cobra.Command {
 	}
 
 	cmd.Flags().BoolP("confirm", "c", false, "Prompt to confirm all options interactively (Env: $FUNC_CONFIRM)")
-	cmd.Flags().StringP("repositories", "r", repositoriesPath(), "Path to language pack repositories (Env: $FUNC_REPOSITORIES)")
+	cmd.Flags().StringP("repositories", "r", fn.RepositoriesPath(), "Path to language pack repositories (Env: $FUNC_REPOSITORIES)")
 
 	cmd.RunE = func(_ *cobra.Command, args []string) error {
 		return runRepositoryRemove(args, clientFn)

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -153,15 +153,6 @@ func cwd() (cwd string) {
 	return cwd
 }
 
-// The anme of the repositories directory within config dir (usually ~/.config)
-const repositoriesDirName = "repositories"
-
-// repositoriesPath is the effective path to the optional repositories directory
-// used for extensible language packs.
-func repositoriesPath() string {
-	return filepath.Join(fn.ConfigPath(), repositoriesDirName)
-}
-
 // bindFunc which conforms to the cobra PreRunE method signature
 type bindFunc func(*cobra.Command, []string) error
 

--- a/docker/pusher.go
+++ b/docker/pusher.go
@@ -90,6 +90,10 @@ func NewCredentialsProvider(
 		}
 	}
 
+	// Creating an instance of the fn.Client ensures that the config path
+	// exists:
+	_ = fn.New()
+
 	authFilePath := filepath.Join(fn.ConfigPath(), "auth.json")
 	sys := &containersTypes.SystemContext{
 		AuthFilePath: authFilePath,


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

# Changes

- :gift: Ensure config and repos paths exist on client instantiation
- :broom: Cleanup existing creation logic invoked by cli

Finalizes the move of config and repositories-path evaluation and creation into the core by creating the directories on instantiation (previously required the CLI), including tests.

Fixes #682
 
/kind enhancement