### PR TITLE
chore: revert using a fork of boson-project/test-templates

### DIFF
--- a/test/_e2e/cmd_config_envs_test.go
+++ b/test/_e2e/cmd_config_envs_test.go
@@ -103,7 +103,7 @@ func TestConfigEnvs(t *testing.T) {
 	project.Template = "envs"
 	project.FunctionName = "test-config-envs"
 	project.ProjectPath = filepath.Join(os.TempDir(), project.FunctionName)
-	project.RemoteRepository = "http://github.com/lance/test-templates.git"
+	project.RemoteRepository = "http://github.com/boson-project/test-templates.git"
 
 	Create(t, knFunc.TestShell, project)
 	defer func() { _ = project.RemoveProjectFolder() }()

--- a/test/_e2e/cmd_config_volumes_test.go
+++ b/test/_e2e/cmd_config_volumes_test.go
@@ -100,7 +100,7 @@ func TestConfigVolumes(t *testing.T) {
 	project.Template = "volumes"
 	project.FunctionName = "test-config-volumes"
 	project.ProjectPath = filepath.Join(os.TempDir(), project.FunctionName)
-	project.RemoteRepository = "http://github.com/lance/test-templates.git"
+	project.RemoteRepository = "http://github.com/boson-project/test-templates.git"
 
 	Create(t, knFunc.TestShell, project)
 	defer project.RemoveProjectFolder()


### PR DESCRIPTION
# Changes

- :broom: revert usage of a fork of the test-templates repository

/kind chore

Depends on https://github.com/boson-project/test-templates/pull/5
