### PR TITLE
chore: remove release-please from ci

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -28,52 +28,14 @@ jobs:
     needs: test
     runs-on: ubuntu-latest
     steps:
-      # Create a release, or update the release PR
-      - uses: GoogleCloudPlatform/release-please-action@v2.24.1
-        id: release
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          release-type: simple
-          bump-minor-pre-major: true
-      # Checkout
       - uses: actions/checkout@v2
-      # Tag
-      # If a release was created, tag `vX.Y.Z` synchronously which:
-      #   1. Triggers release-please to create draft release, allowing manual
-      #      proofreading (and probably editing) of release notes.
-      #      (often raw commit messages are a bit overwhelming, overly granular
-      #      or at least could use some context when included as release notes).
-      #   2. Ensures the tag exists for subsequent action tasks which rely on
-      #      this metadata, such as including version in release binaries.
-      #      The release-please action does add this tag, but asynchronously.
-      # Note that tag is created annotated such that it shows tagging metadata
-      # when queried rather than just the associated commit metadata.
-      - name: tag
-        if: ${{ steps.release.outputs.release_created }}
-        run: |
-          git config user.name github-actions[bot]
-          git tag -d v${{steps.release.outputs.major}}.${{steps.release.outputs.minor}}.${{steps.release.outputs.patch}} || true
-          git push origin :v${{steps.release.outputs.major}}.${{steps.release.outputs.minor}}.${{steps.release.outputs.patch}} || true
-          git tag -a v${{steps.release.outputs.major}}.${{steps.release.outputs.minor}}.${{steps.release.outputs.patch}} -m "Release v${{steps.release.outputs.major}}.${{steps.release.outputs.minor}}.${{steps.release.outputs.patch}}"
-          git push origin v${{steps.release.outputs.major}}.${{steps.release.outputs.minor}}.${{steps.release.outputs.patch}} || true
-
       - uses: actions/setup-go@v2
         with: 
           go-version: "1.16"
-
       # Standard build tasks
       - name: Build
         run: make cross-platform
-          # NOTE:
-          # release-please adds the version asynchronously. Without using the
-          # synchonous tagging step above, the version can be explicitly passed
-          # to the build using the following environment variable.  However this
-          # has the side-effect of causing inter-relese binaries to not include
-          # verbose version information, because the special version `tip` is
-          # overriden with a blank string in those cases.
-          # VERS: ${{ steps.release.outputs.tag_name }}
-
-      # Upload all build artifacts whether it's a release or not
+      # Upload all build artifacts
       - uses: actions/upload-artifact@v2
         with:
           name: OSX Binary
@@ -86,40 +48,3 @@ jobs:
         with:
           name: Windows Binary
           path: func_windows_amd64.exe
-
-      # The following steps are only executed if this is a release
-      - name: Compress Binaries
-        if: ${{ steps.release.outputs.release_created }}
-        run: gzip func_darwin_amd64 func_linux_amd64 func_windows_amd64.exe
-
-      # Upload all binaries
-      - name: Upload Darwin Binary
-        uses: actions/upload-release-asset@v1
-        if: ${{ steps.release.outputs.release_created }}
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ steps.release.outputs.upload_url }}
-          asset_path: ./func_darwin_amd64.gz
-          asset_name: func_darwin_amd64.gz
-          asset_content_type: application/x-gzip
-      - name: Upload Linux Binary
-        uses: actions/upload-release-asset@v1
-        if: ${{ steps.release.outputs.release_created }}
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ steps.release.outputs.upload_url }}
-          asset_path: ./func_linux_amd64.gz
-          asset_name: func_linux_amd64.gz
-          asset_content_type: application/x-gzip
-      - name: Upload Windows Binary
-        uses: actions/upload-release-asset@v1
-        if: ${{ steps.release.outputs.release_created }}
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ steps.release.outputs.upload_url }}
-          asset_path: ./func_windows_amd64.exe.gz
-          asset_name: func_windows_amd64.exe.gz
-          asset_content_type: application/x-gzip


### PR DESCRIPTION
# Changes

Since we are moving towards using the Knative tooling for releases, and because release-please-action will not work in the repository due to knative branch protection rules, I'm removing this from CI entirely as we work towards an alternative solution.

- :broom: remove release-please-action from CI

/kind chore

Signed-off-by: Lance Ball <lball@redhat.com>
