### PR TITLE
fix: make registry validation work again

### DIFF
--- a/cmd/build.go
+++ b/cmd/build.go
@@ -84,7 +84,7 @@ kn func build --builder cnbs/sample-builder:bionic
 	return cmd
 }
 
-func ValidNamespaceAndRegistry() survey.Validator {
+func ValidNamespaceAndRegistry(path string) survey.Validator {
 	return func(val interface{}) error {
 
 		// if the value passed in is the zero value of the appropriate type
@@ -95,7 +95,8 @@ func ValidNamespaceAndRegistry() survey.Validator {
 		_, err := fn.DerivedImage("", val.(string)) //image can be derived without any error
 
 		if err != nil {
-			return errors.New(val.(string) + " Registry and Namespace are required (ie. docker.io/tigerteam). The image name will be derived from the function name.")
+			orig := fmt.Sprintf("Err %+v", err)
+			return errors.New(val.(string) + " Registry and Namespace are required (ie. docker.io/tigerteam). The image name will be derived from the function name. " + orig)
 		}
 		return nil
 	}
@@ -129,7 +130,7 @@ func runBuild(cmd *cobra.Command, _ []string, clientFn buildClientFn) (err error
 
 			err = survey.AskOne(
 				&survey.Input{Message: "Registry for Function images:"},
-				&config.Registry, survey.WithValidator(ValidNamespaceAndRegistry()))
+				&config.Registry, survey.WithValidator(ValidNamespaceAndRegistry(config.Path)))
 			if err != nil {
 				if err == terminal.InterruptErr {
 					return nil

--- a/cmd/build_test.go
+++ b/cmd/build_test.go
@@ -1,0 +1,51 @@
+package cmd
+
+import (
+	"io/ioutil"
+	"testing"
+
+	fn "knative.dev/kn-plugin-func"
+	"knative.dev/kn-plugin-func/mock"
+)
+
+// TestBuildInvalidRegistry ensures that running build specifying the name of the
+// registry explicitly as an argument invokes the registry validation code.
+func TestBuildInvalidRegistry(t *testing.T) {
+	var (
+		args    = []string{"--registry", "foo/bar/foobar/boofar"} // provide an invalid registry name
+		builder = mock.NewBuilder()                               // with a mock builder
+	)
+
+	// Run this test in a temporary directory
+	defer fromTempDir(t)()
+	// Write a func.yaml config which does not specify an image
+	funcYaml := `name: testymctestface
+namespace: ""
+runtime: go
+image: ""
+imageDigest: ""
+builder: quay.io/boson/faas-go-builder
+builders:
+  default: quay.io/boson/faas-go-builder
+envs: []
+annotations: {}
+labels: []
+created: 2021-01-01T00:00:00+00:00
+`
+	if err := ioutil.WriteFile("func.yaml", []byte(funcYaml), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	// Create a command with a client constructor fn that instantiates a client
+	// with a the mocked builder.
+	cmd := NewBuildCmd(func(_ buildConfig) (*fn.Client, error) {
+		return fn.New(fn.WithBuilder(builder)), nil
+	})
+
+	// Execute the command
+	cmd.SetArgs(args)
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("Expected error")
+	}
+}


### PR DESCRIPTION
# Changes

In https://github.com/knative-sandbox/kn-plugin-func/commit/ccf00152be0ceba1794267f8e03a09cb32fee514
the behavior of `NewFunction()` changed slightly, such that it no longer actually
works without a provided and valid path. This was not caught in any of the
tests, because it's the CLI code that was making this call, and the end to end
tests that exercise the build command, use the `--registry` flag, causing
the repository validation code path to be slightly different.

:broom: This commit just adds the path so that `func build` without a `--registry` flag will work again.

EDIT: Converting to a draft, because really, any registry should be validated even if it's provided as a CLI flag. I will add that validation and a test.

/kind fix
