### PR TITLE
Adding ko to produce image with func command

### DIFF
--- a/.ko.yaml
+++ b/.ko.yaml
@@ -1,0 +1,3 @@
+defaultBaseImage: gcr.io/distroless/static:nonroot
+baseImageOverrides:
+  knative.dev/kn-plugin-func/cmd/func: docker.io/library/alpine:latest


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

# Changes
- :gift: Adding `ko` manifest to produce `func` container. 

You can produce a container by running:
```
ko publish ./cmd/func
```

Fixes #691

/kind enhancement


