### PR TITLE
Check for image sha empty before deciding to push

### DIFF
--- a/client.go
+++ b/client.go
@@ -593,16 +593,17 @@ func (c *Client) Deploy(ctx context.Context, path string) (err error) {
 		return ErrNotBuilt
 	}
 
-	// Push the image for the named service to the configured registry
-	imageDigest, err := c.pusher.Push(ctx, f)
-	if err != nil {
-		return
-	}
-
-	// Record the Image Digest pushed.
-	f.ImageDigest = imageDigest
-	if err = f.Write(); err != nil {
-		return
+	if f.ImageDigest == "" {
+		// Push the image for the named service to the configured registry
+		imageDigest, err := c.pusher.Push(ctx, f)
+		if err != nil {
+			return err
+		}
+		// Record the Image Digest pushed.
+		f.ImageDigest = imageDigest
+		if err = f.Write(); err != nil {
+			return err
+		}
 	}
 
 	// Deploy a new or Update the previously-deployed Function


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

# Changes

- :broom: only push image if there is no SHA in the `func.yaml` file. This avoid always pushing on `func deploy` which for integration use cases, requires access to the docker deamon. I will be happy with a different method to achieve the same, instead of checking the image sha in the `func.yaml` file, but we need a way to have a predictable behaviour for `func deploy`. 


/kind cleanup


Fixes #695 
