### PR TITLE
fix: move integration port to unregistered range

### DIFF
--- a/client_int_test.go
+++ b/client_int_test.go
@@ -48,7 +48,7 @@ const (
 	// DefaultRegistry must contain both the registry host and
 	// registry namespace at this time.  This will likely be
 	// split and defaulted to the forthcoming in-cluster registry.
-	DefaultRegistry = "localhost:5000/func"
+	DefaultRegistry = "kind-registry:50000/func"
 
 	// DefaultNamespace for the underlying deployments.  Must be the same
 	// as is set up and configured (see hack/configure.sh)

--- a/docker/credentials_helper_test.go
+++ b/docker/credentials_helper_test.go
@@ -20,7 +20,7 @@ func Test_registryEquals(t *testing.T) {
 		{"localhost with matching port", "https://localhost:1234", "http://localhost:1234", true},
 		{"localhost with match by default port 80", "http://localhost", "localhost:80", true},
 		{"localhost with match by default port 443", "https://localhost", "localhost:443", true},
-		{"localhost with mismatch by non-default port 5000", "https://localhost", "localhost:5000", false},
+		{"localhost with mismatch by non-default port 50000", "https://localhost", "localhost:50000", false},
 		{"localhost with match by empty ports", "https://localhost", "http://localhost", true},
 		{"docker.io matching host https", "https://docker.io", "docker.io", true},
 		{"docker.io matching host http", "http://docker.io", "docker.io", true},

--- a/docker/credentials_helper_test.go
+++ b/docker/credentials_helper_test.go
@@ -20,7 +20,7 @@ func Test_registryEquals(t *testing.T) {
 		{"localhost with matching port", "https://localhost:1234", "http://localhost:1234", true},
 		{"localhost with match by default port 80", "http://localhost", "localhost:80", true},
 		{"localhost with match by default port 443", "https://localhost", "localhost:443", true},
-		{"localhost with mismatch by non-default port 50000", "https://localhost", "localhost:50000", false},
+		{"localhost with mismatch by non-default port 5000", "https://localhost", "localhost:5000", false},
 		{"localhost with match by empty ports", "https://localhost", "http://localhost", true},
 		{"docker.io matching host https", "https://docker.io", "docker.io", true},
 		{"docker.io matching host http", "http://docker.io", "docker.io", true},

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -53,7 +53,7 @@ Allocate a new local cluster by running `hack/allocate.sh`.
 
 The allocation script sets up a local container registry and connects it to the cluster.  This registry must be set as trusted and its address entered in the local hosts file.  This is a one-time configuration and on Linux can be accomplished by running `hack/registry.sh`. 
 
-On other systems, add `127.0.0.1 kind-registry` to your local hosts file and `"insecure-registries" = ["kind-registry:5000"]` to your docker daemon config (`docker/daemon.json`).
+On other systems, add `127.0.0.1 kind-registry` to your local hosts file and `"insecure-registries" = ["kind-registry:50000"]` to your docker daemon config (`docker/daemon.json`).
 
 
 ### Using the Cluster

--- a/function_unit_test.go
+++ b/function_unit_test.go
@@ -21,8 +21,8 @@ func TestFunction_ImageWithDigest(t *testing.T) {
 	}{
 		{
 			name:   "Full path with port",
-			fields: fields{Image: "image-registry.openshift-image-registry.svc.cluster.local:5000/default/bar", ImageDigest: "42"},
-			want:   "image-registry.openshift-image-registry.svc.cluster.local:5000/default/bar@42",
+			fields: fields{Image: "image-registry.openshift-image-registry.svc.cluster.local:50000/default/bar", ImageDigest: "42"},
+			want:   "image-registry.openshift-image-registry.svc.cluster.local:50000/default/bar@42",
 		},
 		{
 			name:   "Path with namespace",

--- a/hack/allocate.sh
+++ b/hack/allocate.sh
@@ -62,8 +62,8 @@ nodes:
       listenAddress: "127.0.0.1"
 containerdConfigPatches:
 - |-
-  [plugins."io.containerd.grpc.v1.cri".registry.mirrors."localhost:5000"]
-    endpoint = ["http://kind-registry:5000"]
+  [plugins."io.containerd.grpc.v1.cri".registry.mirrors."kind-registry:50000"]
+    endpoint = ["http://kind-registry:50000"]
 EOF
   sleep 10
   kubectl wait pod --for=condition=Ready -l '!job-name' -n kube-system --timeout=5m
@@ -179,7 +179,7 @@ registry() {
   # see https://kind.sigs.k8s.io/docs/user/local-registry/
 
   echo "${em}⑥ Registry${me}"
-  docker run -d --restart=always -p "5000:5000" --name "kind-registry" registry:2
+  docker run -d --restart=always -p "50000:50000" --env REGISTRY_HTTP_ADDR="0.0.0.0:50000" --name "kind-registry" registry:2
   docker network connect "kind" "kind-registry"
   kubectl apply -f - <<EOF
 apiVersion: v1
@@ -189,7 +189,7 @@ metadata:
   namespace: kube-public
 data:
   localRegistryHosting.v1: |
-    host: "localhost:5000"
+    host: "kind-registry:50000"
     help: "https://kind.sigs.k8s.io/docs/user/local-registry/"
 EOF
 }
@@ -250,7 +250,7 @@ next_steps() {
   echo "  ${red}add 'kind-registry' "to your local hosts${me} file:"
   echo "    echo \"127.0.0.1 kind-registry\" | sudo tee --append /etc/hosts"
   echo "  ${red}set registry as insecure${me} in the docker daemon config (/etc/docker/daemon.json on linux or ~/.docker/daemon.json on OSX):
-  { \"insecure-registries\": [ \"kind-registry:5000\" ] }"
+  { \"insecure-registries\": [ \"kind-registry:50000\" ] }"
 }
 
 main "$@"

--- a/hack/registry.sh
+++ b/hack/registry.sh
@@ -27,7 +27,7 @@ main() {
 
 set_registry_insecure() {
     echo 'Setting registry as trusted local-only'
-    patch=".\"insecure-registries\" = [\"kind-registry:5000\""]
+    patch=".\"insecure-registries\" = [\"kind-registry:50000\""]
     sudo jq "$patch" /etc/docker/daemon.json > /tmp/daemon.json.tmp && sudo mv /tmp/daemon.json.tmp /etc/docker/daemon.json
     sudo service docker restart
 }

--- a/hack/test-integration-podman.sh
+++ b/hack/test-integration-podman.sh
@@ -5,7 +5,7 @@ unqualified-search-registries = ["docker.io", "quay.io", "registry.fedoraproject
 short-name-mode="permissive"
 
 [[registry]]
-location="localhost:50000"
+location="kind-registry:50000"
 insecure=true
 EOF
 

--- a/hack/test-integration-podman.sh
+++ b/hack/test-integration-podman.sh
@@ -5,7 +5,7 @@ unqualified-search-registries = ["docker.io", "quay.io", "registry.fedoraproject
 short-name-mode="permissive"
 
 [[registry]]
-location="localhost:5000"
+location="localhost:50000"
 insecure=true
 EOF
 

--- a/test/_e2e/config.go
+++ b/test/_e2e/config.go
@@ -7,7 +7,7 @@ import (
 
 // Intended to provide setup configuration for E2E tests
 const (
-	defaultRegistry        = "localhost:50000/user"
+	defaultRegistry        = "kind-registry:50000/user"
 	testTemplateRepository = "http://github.com/lance/test-templates.git" //nolint:varcheck,deadcode
 )
 

--- a/test/_e2e/config.go
+++ b/test/_e2e/config.go
@@ -7,7 +7,7 @@ import (
 
 // Intended to provide setup configuration for E2E tests
 const (
-	defaultRegistry        = "localhost:5000/user"
+	defaultRegistry        = "localhost:50000/user"
 	testTemplateRepository = "http://github.com/lance/test-templates.git" //nolint:varcheck,deadcode
 )
 

--- a/test/_e2e/main_test.go
+++ b/test/_e2e/main_test.go
@@ -56,7 +56,7 @@ func createConfigAuth(dockerConfigFile string, content string) error {
 	if content == "" {
 		content = `{
 	"auths": {
-		"localhost:50000": {
+		"kind-registry:50000": {
 			"auth": "dXNlcjpwYXNzd29yZA=="
 		}
 	}
@@ -82,7 +82,7 @@ func updateConfigAuth(dockerConfigFile string) error {
 		log.Println("Updating ./docker/config.json file with default registry authentication.")
 		exp := regexp.MustCompile(`"auths"[\s]*?[:][\s]*?{`)
 		newContent := exp.ReplaceAll(bcontent, []byte(`"auths": {
-		"localhost:50000": {
+		"kind-registry:50000": {
 			"auth": "dXNlcjpwYXNzd29yZA=="
 		},`))
 

--- a/test/_e2e/main_test.go
+++ b/test/_e2e/main_test.go
@@ -56,7 +56,7 @@ func createConfigAuth(dockerConfigFile string, content string) error {
 	if content == "" {
 		content = `{
 	"auths": {
-		"localhost:5000": {
+		"localhost:50000": {
 			"auth": "dXNlcjpwYXNzd29yZA=="
 		}
 	}
@@ -82,7 +82,7 @@ func updateConfigAuth(dockerConfigFile string) error {
 		log.Println("Updating ./docker/config.json file with default registry authentication.")
 		exp := regexp.MustCompile(`"auths"[\s]*?[:][\s]*?{`)
 		newContent := exp.ReplaceAll(bcontent, []byte(`"auths": {
-		"localhost:5000": {
+		"localhost:50000": {
 			"auth": "dXNlcjpwYXNzd29yZA=="
 		},`))
 

--- a/testdata/cluster.yaml
+++ b/testdata/cluster.yaml
@@ -13,5 +13,5 @@ nodes:
       listenAddress: "127.0.0.1"
 containerdConfigPatches:
 - |-
-  [plugins."io.containerd.grpc.v1.cri".registry.mirrors."localhost:5000"]
-    endpoint = ["http://kind-registry:5000"]
+  [plugins."io.containerd.grpc.v1.cri".registry.mirrors."localhost:50000"]
+    endpoint = ["http://kind-registry:50000"]


### PR DESCRIPTION
:bug: default integraiton port conflict with Mac OS Monteray's new AirPlay listener

Moves the integration testing port into the unregistered range (above
49151) to minimize potential future conflicts.

/kind bug

Fixes #700 