### PR TITLE
Refactor credential provider

### DIFF
--- a/cmd/build.go
+++ b/cmd/build.go
@@ -28,9 +28,8 @@ func newBuildClient(cfg buildConfig) (*fn.Client, error) {
 	pusherOption := fn.WithPusher(nil)
 	if cfg.Push {
 		credentialsProvider := docker.NewCredentialsProvider(
-			newCredentialsCallback(),
-			docker.CheckAuth,
-			newChooseHelperCallback(),
+			docker.WithPromptForCredentials(newCredentialsCallback()),
+			docker.WithPromptForCredentialStore(newChooseHelperCallback()),
 		)
 		pusher, err := docker.NewPusher(
 			docker.WithCredentialsProvider(credentialsProvider),

--- a/cmd/build.go
+++ b/cmd/build.go
@@ -28,8 +28,8 @@ func newBuildClient(cfg buildConfig) (*fn.Client, error) {
 	pusherOption := fn.WithPusher(nil)
 	if cfg.Push {
 		credentialsProvider := docker.NewCredentialsProvider(
-			docker.WithPromptForCredentials(newCredentialsCallback()),
-			docker.WithPromptForCredentialStore(newChooseHelperCallback()),
+			docker.WithPromptForCredentials(newPromptForCredentials()),
+			docker.WithPromptForCredentialStore(newPromptForCredentialStore()),
 		)
 		pusher, err := docker.NewPusher(
 			docker.WithCredentialsProvider(credentialsProvider),

--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -27,8 +27,8 @@ func newDeployClient(cfg deployConfig) (*fn.Client, error) {
 	builder := buildpacks.NewBuilder()
 
 	credentialsProvider := docker.NewCredentialsProvider(
-		docker.WithPromptForCredentials(newCredentialsCallback()),
-		docker.WithPromptForCredentialStore(newChooseHelperCallback()))
+		docker.WithPromptForCredentials(newPromptForCredentials()),
+		docker.WithPromptForCredentialStore(newPromptForCredentialStore()))
 	pusher, err := docker.NewPusher(
 		docker.WithCredentialsProvider(credentialsProvider),
 		docker.WithProgressListener(listener))
@@ -194,7 +194,7 @@ func runDeploy(cmd *cobra.Command, _ []string, clientFn deployClientFn) (err err
 	// (for example kubectl usually uses ~/.kube/config)
 }
 
-func newCredentialsCallback() func(registry string) (docker.Credentials, error) {
+func newPromptForCredentials() func(registry string) (docker.Credentials, error) {
 	firstTime := true
 	return func(registry string) (docker.Credentials, error) {
 		var result docker.Credentials
@@ -228,7 +228,7 @@ func newCredentialsCallback() func(registry string) (docker.Credentials, error) 
 	}
 }
 
-func newChooseHelperCallback() docker.ChooseCredentialHelperCallback {
+func newPromptForCredentialStore() docker.ChooseCredentialHelperCallback {
 	return func(availableHelpers []string) (string, error) {
 		if len(availableHelpers) < 1 {
 			fmt.Fprintf(os.Stderr, `Credentials will not be saved.

--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -27,9 +27,8 @@ func newDeployClient(cfg deployConfig) (*fn.Client, error) {
 	builder := buildpacks.NewBuilder()
 
 	credentialsProvider := docker.NewCredentialsProvider(
-		newCredentialsCallback(),
-		docker.CheckAuth,
-		newChooseHelperCallback())
+		docker.WithPromptForCredentials(newCredentialsCallback()),
+		docker.WithPromptForCredentialStore(newChooseHelperCallback()))
 	pusher, err := docker.NewPusher(
 		docker.WithCredentialsProvider(credentialsProvider),
 		docker.WithProgressListener(listener))

--- a/docker/credentials_helper.go
+++ b/docker/credentials_helper.go
@@ -12,7 +12,6 @@ import (
 	"runtime"
 	"strings"
 
-	"github.com/containers/image/v5/types"
 	"github.com/docker/docker-credential-helpers/client"
 	"github.com/docker/docker-credential-helpers/credentials"
 )
@@ -65,15 +64,15 @@ func setCredentialHelperToConfig(confFilePath, helper string) error {
 	return nil
 }
 
-func getCredentialsByCredentialHelper(confFilePath, registry string) (types.DockerAuthConfig, error) {
-	result := types.DockerAuthConfig{}
+func getCredentialsByCredentialHelper(confFilePath, registry string) (Credentials, error) {
+	result := Credentials{}
 
 	helper, err := getCredentialHelperFromConfig(confFilePath)
 	if err != nil && !os.IsNotExist(err) {
-		return types.DockerAuthConfig{}, fmt.Errorf("failed to get helper from config: %w", err)
+		return result, fmt.Errorf("failed to get helper from config: %w", err)
 	}
 	if helper == "" {
-		return types.DockerAuthConfig{}, errCredentialsNotFound
+		return result, errCredentialsNotFound
 	}
 
 	helperName := fmt.Sprintf("docker-credential-%s", helper)

--- a/docker/pusher.go
+++ b/docker/pusher.go
@@ -103,6 +103,7 @@ type CredentialProviderOptions func(opts *credentialProviderConfig)
 
 // WithPromptForCredentials sets custom callback that is supposed to
 // interactively ask for credentials in case the credentials cannot be found in configuration files.
+// The callback may be called multiple times in case incorrect credentials were returned before.
 func WithPromptForCredentials(cbk CredentialsCallback) CredentialProviderOptions {
 	return func(opts *credentialProviderConfig) {
 		opts.promptForCredentials = cbk

--- a/docker/pusher.go
+++ b/docker/pusher.go
@@ -94,9 +94,9 @@ func CheckAuth(ctx context.Context, registry string, credentials Credentials) er
 type ChooseCredentialHelperCallback func(available []string) (string, error)
 
 type credentialProviderConfig struct {
-	askUser                CredentialsCallback
-	verifyCredentials      VerifyCredentialsCallback
-	chooseCredentialHelper ChooseCredentialHelperCallback
+	promptForCredentials     CredentialsCallback
+	verifyCredentials        VerifyCredentialsCallback
+	promptForCredentialStore ChooseCredentialHelperCallback
 }
 
 type CredentialProviderOptions func(opts *credentialProviderConfig)
@@ -105,7 +105,7 @@ type CredentialProviderOptions func(opts *credentialProviderConfig)
 // interactively ask for credentials in case the credentials cannot be found in configuration files.
 func WithPromptForCredentials(cbk CredentialsCallback) CredentialProviderOptions {
 	return func(opts *credentialProviderConfig) {
-		opts.askUser = cbk
+		opts.promptForCredentials = cbk
 	}
 }
 
@@ -121,7 +121,7 @@ func WithVerifyCredentials(cbk VerifyCredentialsCallback) CredentialProviderOpti
 // from user.
 func WithPromptForCredentialStore(cbk ChooseCredentialHelperCallback) CredentialProviderOptions {
 	return func(opts *credentialProviderConfig) {
-		opts.chooseCredentialHelper = cbk
+		opts.promptForCredentialStore = cbk
 	}
 }
 
@@ -146,7 +146,7 @@ func NewCredentialsProvider(opts ...CredentialProviderOptions) CredentialsProvid
 		o(&conf)
 	}
 
-	askUser, verifyCredentials, chooseCredentialHelper := conf.askUser, conf.verifyCredentials, conf.chooseCredentialHelper
+	askUser, verifyCredentials, chooseCredentialHelper := conf.promptForCredentials, conf.verifyCredentials, conf.promptForCredentialStore
 
 	if verifyCredentials == nil {
 		verifyCredentials = CheckAuth

--- a/docker/pusher.go
+++ b/docker/pusher.go
@@ -14,6 +14,8 @@ import (
 	"regexp"
 	"strings"
 
+	"github.com/containers/image/v5/pkg/docker/config"
+
 	"github.com/google/go-containerregistry/pkg/authn"
 	"github.com/google/go-containerregistry/pkg/name"
 	"github.com/google/go-containerregistry/pkg/v1/remote/transport"
@@ -22,7 +24,6 @@ import (
 
 	fn "knative.dev/kn-plugin-func"
 
-	"github.com/containers/image/v5/pkg/docker/config"
 	containersTypes "github.com/containers/image/v5/types"
 	"github.com/docker/docker/api/types"
 )
@@ -42,9 +43,9 @@ var ErrUnauthorized = errors.New("bad credentials")
 
 // VerifyCredentialsCallback checks if credentials are accepted by the registry.
 // If credentials are incorrect this callback shall return ErrUnauthorized.
-type VerifyCredentialsCallback func(ctx context.Context, username, password, registry string) error
+type VerifyCredentialsCallback func(ctx context.Context, registry string, credentials Credentials) error
 
-func CheckAuth(ctx context.Context, username, password, registry string) error {
+func CheckAuth(ctx context.Context, registry string, credentials Credentials) error {
 	serverAddress := registry
 	if !strings.HasPrefix(serverAddress, "https://") && !strings.HasPrefix(serverAddress, "http://") {
 		serverAddress = "https://" + serverAddress
@@ -53,8 +54,8 @@ func CheckAuth(ctx context.Context, username, password, registry string) error {
 	url := fmt.Sprintf("%s/v2", serverAddress)
 
 	authenticator := &authn.Basic{
-		Username: username,
-		Password: password,
+		Username: credentials.Username,
+		Password: credentials.Password,
 	}
 
 	reg, err := name.NewRegistry(registry)
@@ -134,28 +135,35 @@ func NewCredentialsProvider(
 	return func(ctx context.Context, registry string) (Credentials, error) {
 		result := Credentials{}
 
-		for _, load := range []func() (containersTypes.DockerAuthConfig, error){
-			func() (containersTypes.DockerAuthConfig, error) {
-				return config.GetCredentials(sys, registry)
+		var authLoaders = []CredentialsCallback{
+			func(registry string) (Credentials, error) {
+				creds, err := config.GetCredentials(sys, registry)
+				if err != nil {
+					return Credentials{}, err
+				}
+				return Credentials{
+					Username: creds.Username,
+					Password: creds.Password,
+				}, nil
 			},
-			func() (containersTypes.DockerAuthConfig, error) {
+			func(registry string) (Credentials, error) {
 				return getCredentialsByCredentialHelper(authFilePath, registry)
 			},
-			func() (containersTypes.DockerAuthConfig, error) {
+			func(registry string) (Credentials, error) {
 				return getCredentialsByCredentialHelper(dockerConfigPath, registry)
 			},
-		} {
-			var credentials containersTypes.DockerAuthConfig
-			credentials, err = load()
+		}
+
+		for _, load := range authLoaders {
+
+			result, err = load(registry)
 
 			if err != nil && !errors.Is(err, errCredentialsNotFound) {
 				return Credentials{}, err
 			}
 
-			if credentials != (containersTypes.DockerAuthConfig{}) {
-				result.Username, result.Password = credentials.Username, credentials.Password
-
-				err = verifyCredentials(ctx, result.Username, result.Password, registry)
+			if result != (Credentials{}) {
+				err = verifyCredentials(ctx, registry, result)
 				if err == nil {
 					return result, nil
 				} else {
@@ -172,7 +180,7 @@ func NewCredentialsProvider(
 				return Credentials{}, err
 			}
 
-			err = verifyCredentials(ctx, result.Username, result.Password, registry)
+			err = verifyCredentials(ctx, registry, result)
 			if err == nil {
 				err = setCredentialsByCredentialHelper(authFilePath, registry, result.Username, result.Password)
 				if err != nil {

--- a/docker/pusher_test.go
+++ b/docker/pusher_test.go
@@ -107,7 +107,7 @@ func TestNewCredentialsProvider(t *testing.T) {
 	}
 
 	type args struct {
-		askUser           CredentialsCallback
+		promptUser        CredentialsCallback
 		verifyCredentials VerifyCredentialsCallback
 		registry          string
 		setUpEnv          setUpEnv
@@ -120,7 +120,7 @@ func TestNewCredentialsProvider(t *testing.T) {
 		{
 			name: "test user callback correct password on first try",
 			args: args{
-				askUser:           correctPwdCallback,
+				promptUser:        correctPwdCallback,
 				verifyCredentials: correctVerifyCbk,
 				registry:          "docker.io",
 			},
@@ -129,7 +129,7 @@ func TestNewCredentialsProvider(t *testing.T) {
 		{
 			name: "test user callback correct password on second try",
 			args: args{
-				askUser:           pwdCbkFirstWrongThenCorrect(t),
+				promptUser:        pwdCbkFirstWrongThenCorrect(t),
 				verifyCredentials: correctVerifyCbk,
 				registry:          "docker.io",
 			},
@@ -138,7 +138,7 @@ func TestNewCredentialsProvider(t *testing.T) {
 		{
 			name: "get quay-io credentials with func config populated",
 			args: args{
-				askUser:           pwdCbkThatShallNotBeCalled(t),
+				promptUser:        pwdCbkThatShallNotBeCalled(t),
 				verifyCredentials: correctVerifyCbk,
 				registry:          "quay.io",
 				setUpEnv:          withPopulatedFuncAuthConfig,
@@ -148,7 +148,7 @@ func TestNewCredentialsProvider(t *testing.T) {
 		{
 			name: "get docker-io credentials with func config populated",
 			args: args{
-				askUser:           pwdCbkThatShallNotBeCalled(t),
+				promptUser:        pwdCbkThatShallNotBeCalled(t),
 				verifyCredentials: correctVerifyCbk,
 				registry:          "docker.io",
 				setUpEnv:          withPopulatedFuncAuthConfig,
@@ -158,7 +158,7 @@ func TestNewCredentialsProvider(t *testing.T) {
 		{
 			name: "get quay-io credentials with docker config populated",
 			args: args{
-				askUser:           pwdCbkThatShallNotBeCalled(t),
+				promptUser:        pwdCbkThatShallNotBeCalled(t),
 				verifyCredentials: correctVerifyCbk,
 				registry:          "quay.io",
 				setUpEnv: all(
@@ -170,7 +170,7 @@ func TestNewCredentialsProvider(t *testing.T) {
 		{
 			name: "get docker-io credentials with docker config populated",
 			args: args{
-				askUser:           pwdCbkThatShallNotBeCalled(t),
+				promptUser:        pwdCbkThatShallNotBeCalled(t),
 				verifyCredentials: correctVerifyCbk,
 				registry:          "docker.io",
 				setUpEnv:          withPopulatedDockerAuthConfig,
@@ -187,7 +187,7 @@ func TestNewCredentialsProvider(t *testing.T) {
 			}
 
 			credentialsProvider := NewCredentialsProvider(
-				WithPromptForCredentials(tt.args.askUser),
+				WithPromptForCredentials(tt.args.promptUser),
 				WithVerifyCredentials(tt.args.verifyCredentials))
 			got, err := credentialsProvider(context.Background(), tt.args.registry)
 			if err != nil {

--- a/docker/pusher_test.go
+++ b/docker/pusher_test.go
@@ -381,7 +381,8 @@ func correctPwdCallback(registry string) (Credentials, error) {
 	return Credentials{}, errors.New("this cbk don't know the pwd")
 }
 
-func correctVerifyCbk(ctx context.Context, username, password, registry string) error {
+func correctVerifyCbk(ctx context.Context, registry string, creds Credentials) error {
+	username, password := creds.Username, creds.Password
 	if username == dockerIoUser && password == dockerIoUserPwd && registry == "docker.io" {
 		return nil
 	}
@@ -738,7 +739,11 @@ func TestCheckAuth(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if err := CheckAuth(tt.args.ctx, tt.args.username, tt.args.password, tt.args.registry); (err != nil) != tt.wantErr {
+			creds := Credentials{
+				Username: tt.args.username,
+				Password: tt.args.password,
+			}
+			if err := CheckAuth(tt.args.ctx, tt.args.registry, creds); (err != nil) != tt.wantErr {
 				t.Errorf("CheckAuth() error = %v, wantErr %v", err, tt.wantErr)
 			}
 		})


### PR DESCRIPTION
# Changes

Allow to set custom credential loader.
This might be useful if the registry shares credentials with some other system, e.g. OpenShift builtin registry has the same credentials as the k8s cluster.