### PR TITLE
fix: revert hostname alias

### DIFF
--- a/client_int_test.go
+++ b/client_int_test.go
@@ -48,7 +48,7 @@ const (
 	// DefaultRegistry must contain both the registry host and
 	// registry namespace at this time.  This will likely be
 	// split and defaulted to the forthcoming in-cluster registry.
-	DefaultRegistry = "kind-registry:50000/func"
+	DefaultRegistry = "localhost:50000/func"
 
 	// DefaultNamespace for the underlying deployments.  Must be the same
 	// as is set up and configured (see hack/configure.sh)

--- a/hack/allocate.sh
+++ b/hack/allocate.sh
@@ -62,7 +62,7 @@ nodes:
       listenAddress: "127.0.0.1"
 containerdConfigPatches:
 - |-
-  [plugins."io.containerd.grpc.v1.cri".registry.mirrors."kind-registry:50000"]
+  [plugins."io.containerd.grpc.v1.cri".registry.mirrors."localhost:50000"]
     endpoint = ["http://kind-registry:50000"]
 EOF
   sleep 10
@@ -189,7 +189,7 @@ metadata:
   namespace: kube-public
 data:
   localRegistryHosting.v1: |
-    host: "kind-registry:50000"
+    host: "localhost:50000"
     help: "https://kind.sigs.k8s.io/docs/user/local-registry/"
 EOF
 }

--- a/hack/test-integration-podman.sh
+++ b/hack/test-integration-podman.sh
@@ -5,7 +5,7 @@ unqualified-search-registries = ["docker.io", "quay.io", "registry.fedoraproject
 short-name-mode="permissive"
 
 [[registry]]
-location="kind-registry:50000"
+location="localhost:50000"
 insecure=true
 EOF
 

--- a/test/_e2e/config.go
+++ b/test/_e2e/config.go
@@ -7,7 +7,7 @@ import (
 
 // Intended to provide setup configuration for E2E tests
 const (
-	defaultRegistry        = "kind-registry:50000/user"
+	defaultRegistry        = "localhost:50000/user"
 	testTemplateRepository = "http://github.com/lance/test-templates.git" //nolint:varcheck,deadcode
 )
 

--- a/test/_e2e/main_test.go
+++ b/test/_e2e/main_test.go
@@ -56,7 +56,7 @@ func createConfigAuth(dockerConfigFile string, content string) error {
 	if content == "" {
 		content = `{
 	"auths": {
-		"kind-registry:50000": {
+		"localhost:50000": {
 			"auth": "dXNlcjpwYXNzd29yZA=="
 		}
 	}
@@ -82,7 +82,7 @@ func updateConfigAuth(dockerConfigFile string) error {
 		log.Println("Updating ./docker/config.json file with default registry authentication.")
 		exp := regexp.MustCompile(`"auths"[\s]*?[:][\s]*?{`)
 		newContent := exp.ReplaceAll(bcontent, []byte(`"auths": {
-		"kind-registry:50000": {
+		"localhost:50000": {
 			"auth": "dXNlcjpwYXNzd29yZA=="
 		},`))
 


### PR DESCRIPTION
The localhost alias was causing problems with new approach for registry access.
The new access is done directly not via daemon.
This renders any insecure registry exception in daemon config irrelevant.
The library facilitating registry access seems to allow insecure registry on localhost only.