### PR TITLE
feat!: use `function.knative.dev` for Functions related labels

### DIFF
--- a/knative/deployer.go
+++ b/knative/deployer.go
@@ -349,8 +349,10 @@ func updateService(f fn.Function, newEnv []corev1.EnvVar, newEnvFrom []corev1.En
 //     value: {{ env:MY_ENV }}
 func processLabels(f fn.Function) (map[string]string, error) {
 	labels := map[string]string{
-		"boson.dev/function": "true",
-		"boson.dev/runtime":  f.Runtime,
+		"boson.dev/function":           "true",
+		"boson.dev/runtime":            f.Runtime,
+		"function.knative.dev":         "true",
+		"function.knative.dev/runtime": f.Runtime,
 	}
 	for _, label := range f.Labels {
 		if label.Key != nil && label.Value != nil {


### PR DESCRIPTION
Signed-off-by: Zbynek Roubalik <zroubali@redhat.com>

<!-- Thanks for sending a pull request! -->

# Changes

Proposal:

We should change labels that are applied to Functions from `boson.dev` -> `function.knative.dev` (or `func.knative.dev`).


I am not sure which components are dependent on this, so we should be careful about the change.

