### PR TITLE
fix: ensure pkged.go is migrated

### DIFF
--- a/hack/update-pkger.sh
+++ b/hack/update-pkger.sh
@@ -27,3 +27,6 @@ go run ./vendor/github.com/markbates/pkger/cmd/pkger
 
 # Hack: remove touched file.
 rm "$REPO_ROOT_DIR/hack/package.go"
+
+# Ensure pkged.go is migrated
+gofmt -s -w pkged.go


### PR DESCRIPTION
:bug: adds the missing build stanza to pkged.go by running gofmt which includes the migration in 1.17

Fixes #725 
