### PR TITLE
src: add `ko` to produce image with `func` command in CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -48,3 +48,13 @@ jobs:
         with:
           name: Windows Binary
           path: func_windows_amd64.exe
+  publish-image:
+    needs: test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-go@v2
+        with: 
+          go-version: "1.16"
+      - uses: imjasonh/setup-ko@v0.4
+      - run: ko publish -B ./cmd/func

--- a/.ko.yaml
+++ b/.ko.yaml
@@ -1,0 +1,3 @@
+defaultBaseImage: gcr.io/distroless/static:nonroot
+baseImageOverrides:
+  knative.dev/kn-plugin-func/cmd/func: docker.io/library/alpine:latest


### PR DESCRIPTION
Signed-off-by: Zbynek Roubalik <zroubali@redhat.com>

# Changes
- :gift: Adding `ko` manifest to produce image with `func` command. 
- :gift: `ghcr.io/knative-sandbox/kn-plugin-func/func:latest` image is being produced for each commit on `main` branch

You can produce a container by running:
```
ko publish ./cmd/func
```


Fixes #691

/kind enhancement
