### PR TITLE
src: remove need for hosts entry for local clusters

### DIFF
--- a/hack/allocate.sh
+++ b/hack/allocate.sh
@@ -63,7 +63,7 @@ nodes:
 containerdConfigPatches:
 - |-
   [plugins."io.containerd.grpc.v1.cri".registry.mirrors."localhost:50000"]
-    endpoint = ["http://kind-registry:50000"]
+    endpoint = ["http://kind-registry:5000"]
 EOF
   sleep 10
   kubectl wait pod --for=condition=Ready -l '!job-name' -n kube-system --timeout=5m
@@ -179,7 +179,7 @@ registry() {
   # see https://kind.sigs.k8s.io/docs/user/local-registry/
 
   echo "${em}⑥ Registry${me}"
-  docker run -d --restart=always -p "50000:50000" --env REGISTRY_HTTP_ADDR="0.0.0.0:50000" --name "kind-registry" registry:2
+  docker run -d --restart=always -p "127.0.0.1:50000:5000" --name "kind-registry" registry:2
   docker network connect "kind" "kind-registry"
   kubectl apply -f - <<EOF
 apiVersion: v1
@@ -246,11 +246,9 @@ next_steps() {
   local red=$(tput bold)$(tput setaf 1)
 
   echo "${em}Configure Registry${me}"
-  echo "If not in CI (running ci.sh): 
-  echo "  ${red}add 'kind-registry' "to your local hosts${me} file:"
-  echo "    echo \"127.0.0.1 kind-registry\" | sudo tee --append /etc/hosts"
-  echo "  ${red}set registry as insecure${me} in the docker daemon config (/etc/docker/daemon.json on linux or ~/.docker/daemon.json on OSX):
-  { \"insecure-registries\": [ \"kind-registry:50000\" ] }"
+  echo "If not in CI (running ci.sh): "
+  echo "  ${red}set registry as insecure${me} in the docker daemon config (/etc/docker/daemon.json on linux or ~/.docker/daemon.json on OSX):"
+  echo "    { \"insecure-registries\": [ \"localhost:50000\" ] }"
 }
 
 main "$@"

--- a/hack/delete.sh
+++ b/hack/delete.sh
@@ -19,8 +19,7 @@ main() {
   docker stop kind-registry && docker rm kind-registry
   docker network rm kind
   echo "${red}NOTE:${reset}  The following changes have not been undone:"
-  echo " - Manual etc/hosts entry for kind-registry"
-  echo " - Manual docker config registering kind-registry as insecure"
+  echo " - Manual docker config registering registry at localhost:50000 (kind-registry) as insecure"
   echo " - Downloaded container images were not removed"
   echo "${green}DONE${reset}"
 }

--- a/hack/registry.sh
+++ b/hack/registry.sh
@@ -1,9 +1,7 @@
 #!/usr/bin/env bash
 
 # 
-# Set up local registry (linux only)
-# - Registers registry with Docker as trusted
-# - Adds 'kind-rgistry' to /etc/hosts
+# - Registers registry with Docker as trusted (linux only)
 #
 
 set -o errexit
@@ -19,7 +17,6 @@ main() {
   echo "${em}Configuring for CI...${me}"
 
   set_registry_insecure
-  patch_hosts
 
   echo "${em}DONE${me}"
 
@@ -27,14 +24,9 @@ main() {
 
 set_registry_insecure() {
     echo 'Setting registry as trusted local-only'
-    patch=".\"insecure-registries\" = [\"kind-registry:50000\""]
+    patch=".\"insecure-registries\" = [\"localhost:50000\""]
     sudo jq "$patch" /etc/docker/daemon.json > /tmp/daemon.json.tmp && sudo mv /tmp/daemon.json.tmp /etc/docker/daemon.json
     sudo service docker restart
-}
-
-patch_hosts() {
-    echo 'Adding registry to hosts'
-    echo "127.0.0.1 kind-registry" | sudo tee --append /etc/hosts
 }
 
 main "$@"


### PR DESCRIPTION
- :broom: remove need for hosts entry for local clusters

We can now simply refer to localhost throughout.  This PR reflects that in the local allocation system.

/kind techdebt