### PR TITLE
Tekton tasks for `func build` and `func deploy`

### DIFF
--- a/task/func-build/0.1/README.md
+++ b/task/func-build/0.1/README.md
@@ -1,0 +1,133 @@
+# Build a Knative `func` project
+
+This Task uses the `func` CLI to build a `func` project. 
+[`func`](https://github.com/knative-sandbox/kn-plugin-func) CLI.
+
+Knative `func` uses [Buildpacks](http://buildpacks.io) to build a container image. This task also push the created containe image to a container image registry, hence it requires access to the container runtime. 
+
+
+## Install the Task
+
+```
+kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/main/task/func-build/0.1/func-build.yaml
+```
+
+## Parameters
+
+* **kn-image**: `kn` CLI container image to run this task.
+
+  _default_: `gcr.io/knative-releases/knative.dev/client/cmd/kn:latest`
+
+  You can use nightly build of the `kn` CLI using
+  `gcr.io/knative-nightly/knative.dev/client/cmd/kn`.
+
+
+* **ARGS**: The arguments to pass to `kn` CLI.  _default_: `["help"]`
+
+## Resources
+
+### Inputs
+
+* **image**: An `image`-type `PipelineResource` specifying the location of the
+  container image to deploy for Knative Service.
+
+  User provides the `image`-type resource to kn CLI in parameter `ARGS` as an
+  element of the array, for e.g. `"--image=$(inputs.resources.image.url)"`.
+
+## Platforms
+
+The Task can be run on `linux/amd64`, `linux/s390x`, `linux/arm64` and `linux/ppc64le` platforms.
+
+## Usage
+
+### Authorizing the Deployment
+
+In order to create Knative services, you must first define a `ServiceAccount`
+with permission to manage Knative resources.
+
+To create a `ServiceAccount` with these permissions, you can run:
+
+```
+kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/main/task/kn/0.1/support/kn-deployer.yaml
+```
+
+### Running the Task
+
+Let's take examples of creating and updating a Knative Service using `kn` task.
+
+1. Following TaskRun runs the Task to create a Knative Service using given image.
+
+```
+apiVersion: tekton.dev/v1beta1
+kind: TaskRun
+metadata:
+  generateName: kn-create-
+spec:
+  serviceAccountName: kn-deployer-account  # <-- run as the authorized SA
+  taskRef:
+    name: kn
+  resources:
+    inputs:
+    - name: image
+      resourceSpec:
+        type: image
+        params:
+        - name: url
+          value: gcr.io/knative-samples/helloworld-go
+  params:
+  - name: ARGS
+    value:
+    - "service"
+    - "create"
+    - "hello"
+    - "--force"
+    - "--image=$(inputs.resources.image.url)"
+```
+
+Run this with:
+
+```
+kubectl create -f kn-create-taskrun.yaml
+```
+
+2. Following TaskRun runs the Task to update a Knative Service using given image or parameters.
+
+```
+apiVersion: tekton.dev/v1beta1
+kind: TaskRun
+metadata:
+  generateName: kn-update-
+spec:
+  serviceAccountName: kn-deployer-account  # <-- run as the authorized SA
+  taskRef:
+    name: kn
+  resources:
+    inputs:
+    - name: image
+      resourceSpec:
+        type: image
+        params:
+        - name: url
+          value: gcr.io/knative-samples/helloworld-go
+  params:
+  - name: ARGS
+    value:
+    - "service"
+    - "update"
+    - "hello"
+    - "--image=$(inputs.resources.image.url)"
+    - "--env=TARGET=Tekton"
+```
+
+Run this with:
+
+```
+kubectl create -f kn-update-taskrun.yaml
+```
+
+In these examples, the `image` resource can be built before hand, most
+likely using a previous task.
+
+## Pipeline
+Checkout the sample Pipelines for building your git source and deploying
+as Knative Service [here](./knative-dockerfile-deploy/README.md).

--- a/task/func-build/0.1/func-build.yaml
+++ b/task/func-build/0.1/func-build.yaml
@@ -1,0 +1,74 @@
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: func-build
+  labels:
+    app.kubernetes.io/version: "0.1"
+  annotations:
+    tekton.dev/pipelines.minVersion: "0.12.1"
+    tekton.dev/categories: CLI
+    tekton.dev/tags: cli
+    tekton.dev/platforms: "linux/amd64"
+spec:
+  description: >-
+    This Task performs the build operation using Knative `func` CLI
+  params:
+  - name: func-image
+    description: func CLI container image to run this task
+    default: salaboy/func-2e37ecdd2ee11985d861179f5d0a0fbb@sha256:33468313582069d2e6ea850cd526858918db215c1bf98558ece2f8967201937f #func built with `ko publish ./cmd/func`
+  - name: path
+    description: path where the function project lives
+  - name: registry
+    description: registry where the function container image will be pushed  
+  - name: USER_ID
+    description: The user ID of the builder image user.
+    default: "1000"
+  - name: GROUP_ID
+    description: The group ID of the builder image user.
+    default: "1000"
+  workspaces:
+    - name: output
+      description: The workspace containing the `func` project.   
+  results:
+    - name: APP_IMAGE_DIGEST
+      description: The digest of the built container image. 
+  volumes:
+    - name: dockersock
+      hostPath:
+        path: /var/run/docker.sock       
+  steps:
+  - name: prepare
+    image: docker.io/library/bash:5.1.4@sha256:b208215a4655538be652b2769d82e576bc4d0a2bb132144c060efc5be8c3f5d6
+    script: |
+        #!/usr/bin/env bash
+        set -e
+        for path in "/tekton/home" "$(workspaces.output.path)"; do
+          echo "> Setting permissions on '$path'..."
+          chown -R "$(params.USER_ID):$(params.GROUP_ID)" "$path"
+        done 
+  - name: func-build
+    image: "$(params.func-image)"
+    command: ["func"]
+    args: 
+      - "build"
+      - "-v"
+      - "-p"
+      - "$(params.path)"
+      - "-r"
+      - "$(params.registry)"
+    securityContext:
+      privileged: true
+      runAsUser: 1000
+      runAsGroup: 1000
+    volumeMounts:
+      - name: dockersock
+        mountPath: "/var/run/docker.sock"    
+  - name: results
+    image: docker.io/library/bash:5.1.4@sha256:b208215a4655538be652b2769d82e576bc4d0a2bb132144c060efc5be8c3f5d6
+    script: |
+        #!/usr/bin/env bash
+        set -e
+        cat $(params.path)/func.yaml | grep imageDigest | awk '{print $2}' | tee $(results.APP_IMAGE_DIGEST.path)
+        cat $(results.APP_IMAGE_DIGEST.path)
+      
+

--- a/task/func-deploy/0.1/func-deploy.yaml
+++ b/task/func-deploy/0.1/func-deploy.yaml
@@ -1,0 +1,36 @@
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: func-deploy
+  labels:
+    app.kubernetes.io/version: "0.1"
+  annotations:
+    tekton.dev/pipelines.minVersion: "0.12.1"
+    tekton.dev/categories: CLI
+    tekton.dev/tags: cli
+    tekton.dev/platforms: "linux/amd64"
+spec:
+  description: >-
+    This Task performs operations using Knative `func` CLI
+  params:
+  - name: func-image
+    description: func CLI container image to run this task
+    default: salaboy/func-2e37ecdd2ee11985d861179f5d0a0fbb@sha256:33468313582069d2e6ea850cd526858918db215c1bf98558ece2f8967201937f #func built with `ko publish ./cmd/func`
+  - name: path
+    description: path where the function project lives  
+  workspaces:
+    - name: output
+      description: The workspace containing the `func` project.   
+  steps:
+  - name: func-deploy
+    image: "$(params.func-image)"
+    command: ["func"]
+    args: 
+      - "deploy"
+      - "-v"
+      - "-c=false"
+      - "-b=false"
+      - "-p"
+      - "$(params.path)"
+      
+

--- a/task/func-deploy/0.1/support/knative-deployer.yaml
+++ b/task/func-deploy/0.1/support/knative-deployer.yaml
@@ -1,0 +1,39 @@
+# Define a ServiceAccount named knative-deployer-account that has permission to
+# manage Knative services.
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: dockerconfig
+secrets:
+  - name: regcred
+---
+
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: knative-deployer-account
+  namespace: default
+---
+
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: kn-deployer
+rules:
+  - apiGroups: ["serving.knative.dev"]
+    resources: ["services", "revisions", "routes"]
+    verbs: ["get", "list", "create", "update", "delete", "patch", "watch"]
+---
+
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  name: knative-deployer-binding
+subjects:
+- kind: ServiceAccount
+  name: knative-deployer-account
+  namespace: default
+roleRef:
+  kind: ClusterRole
+  name: kn-deployer
+  apiGroup: rbac.authorization.k8s.io


### PR DESCRIPTION
# Changes
- :gift: Add Tekton Tasks definitions. This PR uses the `task/` directory to follow the [Tekton Catalog](https://github.com/tektoncd/catalog) layout for tasks, so moving them there should be easier. 

Fixes #745 

/kind  enhancement

