### PR TITLE
feat: improve help text for all commands

### DIFF
--- a/cmd/build.go
+++ b/cmd/build.go
@@ -67,26 +67,29 @@ func NewBuildCmd(clientFn buildClientFn) *cobra.Command {
 		Short: "Build a function project as a container image",
 		Long: `Build a function project as a container image
 
-This command builds the function project in the current directory or in the directory
-specified by --path. The result will be a container image that is pushed to a registry.
-The func.yaml file is read to determine the image name and registry. 
-If the project has not already been built, either --registry or --image must be provided 
-and the image name is stored in the configuration file.
+This command builds the function project in the current directory or
+in the directory specified by --path. The result will be a container
+image that is pushed to a registry. The func.yaml file is read to
+determine the image name and registry. 
+
+If the project has not already been built, either --registry or
+--image must be provided and the image name is stored in the
+configuration file.
 `,
 		Example: `
 # Build from the local directory, using the given registry as target.
 # The full image name will be determined automatically based on the
 # project directory name
-kn func build --registry quay.io/myuser
+{{.Prefix}}func build --registry quay.io/myuser
 
 # Build from the local directory, specifying the full image name
-kn func build --image quay.io/myuser/myfunc
+{{.Prefix}}func build --image quay.io/myuser/myfunc
 
-# Re-build, picking up a previously supplied image name from a local func.yml
-kn func build
+# Re-build, using a previously supplied image name from a local func.yml
+{{.Prefix}}func build
 
 # Build with a custom buildpack builder
-kn func build --builder cnbs/sample-builder:bionic
+{{.Prefix}}func build --builder cnbs/sample-builder:bionic
 `,
 		SuggestFor: []string{"biuld", "buidl", "built"},
 		PreRunE:    bindEnv("image", "path", "builder", "registry", "confirm", "push"),
@@ -98,6 +101,13 @@ kn func build --builder cnbs/sample-builder:bionic
 	cmd.Flags().StringP("registry", "r", "", "Registry + namespace part of the image to build, ex 'quay.io/myuser'.  The full image name is automatically determined based on the local directory name. If not provided the registry will be taken from func.yaml (Env: $FUNC_REGISTRY)")
 	cmd.Flags().BoolP("push", "u", false, "Attempt to push the function image after being successfully built")
 	setPathFlag(cmd)
+
+	cmd.SetHelpFunc(func(cmd *cobra.Command, args []string) {
+		runCommandHelp(cmd, "build")
+	})
+	cmd.SetUsageFunc(func(cmd *cobra.Command) error {
+		return runCommandUsage(cmd, "{{.Prefix}}func build [flags]")
+	})
 
 	if err := cmd.RegisterFlagCompletionFunc("builder", CompleteBuilderList); err != nil {
 		fmt.Println("internal: error while calling RegisterFlagCompletionFunc: ", err)

--- a/cmd/delete.go
+++ b/cmd/delete.go
@@ -40,22 +40,22 @@ type deleteClientFn func(deleteConfig) (*fn.Client, error)
 
 func NewDeleteCmd(clientFn deleteClientFn) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "delete [NAME]",
+		Use:   "delete",
 		Short: "Undeploy a function",
 		Long: `Undeploy a function
 
-This command undeploys a function from the cluster. By default the function from 
-the project in the current directory is undeployed. Alternatively either the name 
-of the function can be given as argument or the project path provided with --path.
+This command undeploys a function from the cluster. By default the
+function from the project in the current directory is undeployed.
+Alternatively either the name of the function or the project path
+may be provided with --path.
 
 No local files are deleted.
 `,
-		Example: `
-# Undeploy the function defined in the local directory
-kn func delete
+		Example: `# Undeploy the function defined in the local directory
+{{.Prefix}}func delete
 
 # Undeploy the function 'myfunc' in namespace 'apps'
-kn func delete -n apps myfunc
+{{.Prefix}}func delete -n apps myfunc
 `,
 		SuggestFor:        []string{"remove", "rm", "del"},
 		ValidArgsFunction: CompleteFunctionList,
@@ -65,6 +65,13 @@ kn func delete -n apps myfunc
 	cmd.Flags().BoolP("confirm", "c", false, "Prompt to confirm all configuration options (Env: $FUNC_CONFIRM)")
 	setNamespaceFlag(cmd)
 	setPathFlag(cmd)
+
+	cmd.SetHelpFunc(func(cmd *cobra.Command, args []string) {
+		runCommandHelp(cmd, "delete")
+	})
+	cmd.SetUsageFunc(func(cmd *cobra.Command) error {
+		return runCommandUsage(cmd, "{{.Prefix}}func delete [NAME] [flags]")
+	})
 
 	cmd.RunE = func(cmd *cobra.Command, args []string) error {
 		return runDelete(cmd, args, clientFn)

--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -90,24 +90,25 @@ func NewDeployCmd(clientFn deployClientFn) *cobra.Command {
 		Short: "Deploy a function",
 		Long: `Deploy a function
 
-Builds a container image for the function and deploys it to the connected Knative enabled cluster. 
-The function is picked up from the project in the current directory or from the path provided
-with --path.
-If not already configured, either --registry or --image has to be provided and is then stored 
-in the configuration file.
+Builds a container image for the function and deploys it to the
+connected Knative enabled cluster. The function is picked up from the
+project in the current directory or from the path provided in --path.
+If not already configured, either --registry or --image has to be
+provided and is then stored in the configuration file.
 
-If the function is already deployed, it is updated with a new container image
-that is pushed to an image registry, and finally the function's Knative service is updated.
+If the function is already deployed, it is updated with a new
+container image that is pushed to an image registry, and finally the
+function's Knative service is updated.
 `,
-		Example: `
-# Build and deploy the function from the current directory's project. The image will be
-# pushed to "quay.io/myuser/<function name>" and deployed as Knative service with the 
-# same name as the function to the currently connected cluster.
-kn func deploy --registry quay.io/myuser
+		Example: `# Build and deploy the function from the current directory's project.
+# The image will be pushed to "quay.io/myuser/<function name>" and
+# deployed as Knative service with the same name as the function to
+# the currently connected cluster.
+{{.Prefix}}func deploy --registry quay.io/myuser
 
-# Same as above but using a full image name, that will create a Knative service "myfunc" in 
-# the namespace "myns"
-kn func deploy --image quay.io/myuser/myfunc -n myns
+# Same as above but using a full image name, that will create a
+# Knative service "myfunc" in the namespace "myns"
+{{.Prefix}}func deploy --image quay.io/myuser/myfunc -n myns
 `,
 		SuggestFor: []string{"delpoy", "deplyo"},
 		PreRunE:    bindEnv("image", "namespace", "path", "registry", "confirm", "build", "push"),
@@ -123,6 +124,13 @@ kn func deploy --image quay.io/myuser/myfunc -n myns
 	cmd.Flags().BoolP("push", "u", true, "Attempt to push the function image to registry before deploying (Env: $FUNC_PUSH)")
 	setPathFlag(cmd)
 	setNamespaceFlag(cmd)
+
+	cmd.SetHelpFunc(func(cmd *cobra.Command, args []string) {
+		runCommandHelp(cmd, "deploy")
+	})
+	cmd.SetUsageFunc(func(cmd *cobra.Command) error {
+		return runCommandUsage(cmd, "{{.Prefix}}func deploy [flags]")
+	})
 
 	cmd.RunE = func(cmd *cobra.Command, args []string) error {
 		return runDeploy(cmd, args, clientFn)

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -47,15 +47,14 @@ func NewListCmd(clientFn listClientFn) *cobra.Command {
 
 Lists all deployed functions in a given namespace.
 `,
-		Example: `
-# List all functions in the current namespace with human readable output
-kn func list
+		Example: `# List all functions in the current namespace in human readable form
+{{.Prefix}}func list
 
 # List all functions in the 'test' namespace with yaml output
-kn func list --namespace test --output yaml
+{{.Prefix}}func list --namespace test --output yaml
 
 # List all functions in all namespaces with JSON output
-kn func list --all-namespaces --output json
+{{.Prefix}}func list --all-namespaces --output json
 `,
 		SuggestFor: []string{"ls", "lsit"},
 		PreRunE:    bindEnv("namespace", "output"),
@@ -64,6 +63,13 @@ kn func list --all-namespaces --output json
 	cmd.Flags().BoolP("all-namespaces", "A", false, "List functions in all namespaces. If set, the --namespace flag is ignored.")
 	cmd.Flags().StringP("output", "o", "human", "Output format (human|plain|json|xml|yaml) (Env: $FUNC_OUTPUT)")
 	setNamespaceFlag(cmd)
+
+	cmd.SetHelpFunc(func(cmd *cobra.Command, args []string) {
+		runCommandHelp(cmd, "list")
+	})
+	cmd.SetUsageFunc(func(cmd *cobra.Command) error {
+		return runCommandUsage(cmd, "{{.Prefix}}func list [flags]")
+	})
 
 	if err := cmd.RegisterFlagCompletionFunc("output", CompleteOutputFormatList); err != nil {
 		fmt.Println("internal: error while calling RegisterFlagCompletionFunc: ", err)

--- a/cmd/repository.go
+++ b/cmd/repository.go
@@ -45,19 +45,17 @@ func newRepositoryClient(args []string) (repositoryConfig, RepositoryClient, err
 
 func NewRepositoryCmd(clientFn repositoryClientFn) *cobra.Command {
 	cmd := &cobra.Command{
-		Short:   "Manage installed template repositories",
+		Short:   "Manage template repositories",
 		Use:     "repository",
 		Aliases: []string{"repo", "repositories"},
-		Long: `
-NAME
-	func-repository - Manage set of installed repositories.
+		Long: `Manage the installed set of template repositories.
 
 SYNOPSIS
-	func repo [-c|--confirm] [-v|--verbose]
-	func repo list [-r|--repositories] [-c|--confirm] [-v|--verbose]
-	func repo add <name> <url>[-r|--repositories] [-c|--confirm] [-v|--verbose]
-	func repo rename <old> <new> [-r|--repositories] [-c|--confirm] [-v|--verbose]
-	func repo remove <name> [-r|--repositories] [-c|--confirm] [-v|--verbose]
+	{{.Prefix}}func repo [-c|--confirm] [-v|--verbose]
+	{{.Prefix}}func repo list [-r|--repositories] [-c|--confirm] [-v|--verbose]
+	{{.Prefix}}func repo add <name> <url>[-r|--repositories] [-c|--confirm] [-v|--verbose]
+	{{.Prefix}}func repo rename <old> <new> [-r|--repositories] [-c|--confirm] [-v|--verbose]
+	{{.Prefix}}func repo remove <name> [-r|--repositories] [-c|--confirm] [-v|--verbose]
 
 DESCRIPTION
 	Manage template repositories installed on disk at either the default location
@@ -82,7 +80,7 @@ DESCRIPTION
 	specifying a repository name prefix.
 	For example, to create a new Go function using the 'http' template from the
 	default repository.
-		$ func create -l go -t http
+		$ {{.Prefix}}func create -l go -t http
 
 	The Repository Flag:
 	Installing repositories locally is optional.  To use a template from a remote
@@ -90,7 +88,7 @@ DESCRIPTION
 	This leaves the local disk untouched.  For example, To create a Function using
 	the Boson Project Hello-World template without installing the template
 	repository locally, use the --repository (-r) flag on create:
-		$ func create -l go \
+		$ {{.Prefix}}func create -l go \
 			--template hello-world \
 			--repository https://github.com/boson-project/templates
 
@@ -98,19 +96,19 @@ COMMANDS
 
 	With no arguments, this help text is shown.  To manage repositories with
 	an interactive prompt, use the use the --confirm (-c) flag.
-	  $ func repository -c
+	  $ {{.Prefix}}func repository -c
 
 	add
 	  Add a new repository to the installed set.
-	    $ func repository add <name> <URL>
+	    $ {{.Prefix}}func repository add <name> <URL>
 
 	  For Example, to add the Boson Project repository:
-	    $ func repository add boson https://github.com/boson-project/templates
+	    $ {{.Prefix}}func repository add boson https://github.com/boson-project/templates
 
 	  Once added, a Function can be created with templates from the new repository
 	  by prefixing the template name with the repository.  For example, to create
 	  a new Function using the Go Hello World template:
-	    $ func create -l go -t boson/hello-world
+	    $ {{.Prefix}}func create -l go -t boson/hello-world
 
 	list
 	  List all available repositories, including the installed default
@@ -120,7 +118,7 @@ COMMANDS
 	rename
 	  Rename a previously installed repository from <old> to <new>. Only installed
 	  repositories can be renamed.
-	    $ func repository rename <name> <new name>
+	    $ {{.Prefix}}func repository rename <name> <new name>
 
 	remove
 	  Remove a repository by name.  Removes the repository from local storage
@@ -128,41 +126,41 @@ COMMANDS
 	  deletion, but in regular mode this is done immediately, so please use
 	  caution, especially when using an altered repositories location
 	  (FUNC_REPOSITORIES environment variable or --repositories).
-	    $ func repository remove <name>
+	    $ {{.Prefix}}func repository remove <name>
+`,
+		Example: `
+o Run in confirmation mode (interactive prompts) using the --confirm flag
+	$ {{.Prefix}}func repository -c
 
-EXAMPLES
-	o Run in confirmation mode (interactive prompts) using the --confirm flag
-	  $ func repository -c
+o Add a repository and create a new Function using a template from it:
+	$ {{.Prefix}}func repository add boson https://github.com/boson-project/templates
+	$ {{.Prefix}}func repository list
+	default
+	boson
+	$ {{.Prefix}}func create -l go -t boson/hello-world
+	...
 
-	o Add a repository and create a new Function using a template from it:
-	  $ func repository add boson https://github.com/boson-project/templates
-	  $ func repository list
-	  default
-	  boson
-	  $ func create -l go -t boson/hello-world
-	  ...
+o List all repositories including the URL from which remotes were installed
+	$ {{.Prefix}}func repository list -v
+	default
+	boson	https://github.com/boson-project/templates
 
-	o List all repositories including the URL from which remotes were installed
-	  $ func repository list -v
-	  default
-	  boson	https://github.com/boson-project/templates
+o Rename an installed repository
+	$ {{.Prefix}}func repository list
+	default
+	boson
+	$ {{.Prefix}}func repository rename boson boson-examples
+	$ {{.Prefix}}func repository list
+	default
+	boson-examples
 
-	o Rename an installed repository
-	  $ func repository list
-	  default
-	  boson
-	  $ func repository rename boson boson-examples
-	  $ func repository list
-	  default
-	  boson-examples
-
-	o Remove an installed repository
-	  $ func repository list
-	  default
-	  boson-examples
-	  $ func repository remove boson-examples
-	  $ func repository list
-	  default
+o Remove an installed repository
+	$ {{.Prefix}}func repository list
+	default
+	boson-examples
+	$ {{.Prefix}}func repository remove boson-examples
+	$ {{.Prefix}}func repository list
+	default
 `,
 		SuggestFor: []string{"repositories", "repos", "template", "templates", "pack", "packs"},
 		PreRunE:    bindEnv("repositories", "confirm"),
@@ -170,6 +168,14 @@ EXAMPLES
 
 	cmd.Flags().BoolP("confirm", "c", false, "Prompt to confirm all options interactively (Env: $FUNC_CONFIRM)")
 	cmd.Flags().StringP("repositories", "r", fn.RepositoriesPath(), "Path to language pack repositories (Env: $FUNC_REPOSITORIES)")
+
+	cmd.SetHelpFunc(func(cmd *cobra.Command, args []string) {
+		runCommandHelp(cmd, "repositories")
+	})
+	cmd.SetUsageFunc(func(cmd *cobra.Command) error {
+		return runCommandUsage(cmd, `{{.Prefix}}func repository [flags]
+  {{.Prefix}}func repository [commands]`)
+	})
 
 	cmd.RunE = func(cmd *cobra.Command, args []string) error {
 		return runRepository(cmd, args, clientFn)

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -41,18 +41,19 @@ func NewRunCmd(clientFn runClientFn) *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:   "run",
-		Short: "Run the function locally",
-		Long: `Run the function locally
+		Short: "Run a Function locally",
+		Long: `Run a Function in the local environment
 
-Runs the function locally in the current directory or in the directory
-specified by --path flag. The function must already have been built with the 'build' command.
+Runs a Function locally in the current directory or in the directory
+specified by --path flag. The function must already have been built
+with the 'build' command.
 `,
 		Example: `
 # Build function's image first
-kn func build
+{{.Prefix}}func build
 
 # Run it locally as a container
-kn func run
+{{.Prefix}}func run
 `,
 		SuggestFor: []string{"rnu"},
 		PreRunE:    bindEnv("build", "path"),
@@ -63,7 +64,14 @@ kn func run
 			"You may provide this flag multiple times for setting multiple environment variables. "+
 			"To unset, specify the environment variable name followed by a \"-\" (e.g., NAME-).")
 	setPathFlag(cmd)
-	cmd.Flags().BoolP("build", "b", false, "Build the function only if the function has not been built before")
+	cmd.Flags().BoolP("build", "b", false, "Build the function if it has not been previously built")
+
+	cmd.SetHelpFunc(func(cmd *cobra.Command, args []string) {
+		runCommandHelp(cmd, "run")
+	})
+	cmd.SetUsageFunc(func(cmd *cobra.Command) error {
+		return runCommandUsage(cmd, "{{.Prefix}}func run [flags]")
+	})
 
 	cmd.RunE = func(cmd *cobra.Command, args []string) error {
 		return runRun(cmd, args, clientFn)


### PR DESCRIPTION
:gift: Standardize all help text to be filtered through a prefix/name handling function which can deal with `kn` vs `kn func` vs `kn-func`. Work in progress.

Improve this PR to add
- [ ] code documentation
- [ ] standard text width for all command help text (I prefer 70)
- [ ] move additional functions in cmd/root.go to cmd/help-helper.go or similar
- [ ] implications with lack of fully formed formatting capabilities (e.g.) for features in cobra we don't use
- [ ] address kn-func as a plugin
- [ ] address kn-func as a standalone binary

/kind enhancement

Fixes: https://github.com/knative-sandbox/kn-plugin-func/issues/216