### PR TITLE
test: fix URL

### DIFF
--- a/http/transport_test.go
+++ b/http/transport_test.go
@@ -17,7 +17,7 @@ import (
 	fnhttp "knative.dev/kn-plugin-func/http"
 )
 
-const inClusterHostName = "image-registry.openshift-image-registry.svc"
+const inClusterHostName = "a-testing-service.a-testing-namespace.svc"
 
 func TestCustomCA(t *testing.T) {
 	var err error


### PR DESCRIPTION
On CI machines the image registry is present and reachable.
That causes the actual registry, not mock server, is accessed by the test.
