### PR TITLE
chore: skip integration tests in upstream release scripts for now

### DIFF
--- a/test/presubmit-tests.sh
+++ b/test/presubmit-tests.sh
@@ -48,13 +48,13 @@ function unit_tests() {
 }
 
 function integration_tests() {
-  header "Running func integration tests"
-  make test-integration || failed=1
+  header "Skipping func integration tests"
+  # make test-integration || failed=1
 
-  if (( failed )); then
-    results_banner "Integration tests failed"
-    exit ${failed}
-  fi
+  # if (( failed )); then
+  #   results_banner "Integration tests failed"
+  #   exit ${failed}
+  # fi
 }
 
 main $@


### PR DESCRIPTION
- :broom: skip integration tests in upstream knative release infra

This is temporary to see if we can actually get releases going without having the additional burden of ensuring that a cluster and docker are available for tests.

/kind chore