### PR TITLE
chore: update Makefile and hack/release.sh to accept TAG

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,10 +13,12 @@ BIN_WINDOWS ?= $(BIN)_windows_amd64.exe
 # Version
 # A verbose version is built into the binary including a date stamp, git commit
 # hash and the version tag of the current commit (semver) if it exists.
-# If the current commit does not have a semver tag, 'tip' is used.
+# If the current commit does not have a semver tag, 'tip' is used, unless there
+# is a TAG environment variable. Precedence is git tag, environment variable, 'tip'
 DATE    := $(shell date -u +"%Y%m%dT%H%M%SZ")
 HASH    := $(shell git rev-parse --short HEAD 2>/dev/null)
 VTAG    := $(shell git tag --points-at HEAD)
+VTAG    := $(shell [ -z $(VTAG) ] && echo $(TAG) || echo $(VTAG))
 VERS    ?= $(shell [ -z $(VTAG) ] && echo 'tip' || echo $(VTAG) )
 LDFLAGS := "-X main.date=$(DATE) -X main.vers=$(VERS) -X main.hash=$(HASH)"
 

--- a/hack/release.sh
+++ b/hack/release.sh
@@ -23,7 +23,7 @@ source $(dirname $0)/../vendor/knative.dev/hack/release.sh
 
 function build_release() {
   echo "🚧 🐧 Building cross platform binaries: Linux 🐧 (amd64), MacOS 🍏, and Windows 🎠"
-  make cross-platform
+  TAG=${TAG} make cross-platform
 
   ARTIFACTS_TO_PUBLISH="func_darwin_amd64 func_linux_amd64 func_windows_amd64.exe"
   sha256sum ${ARTIFACTS_TO_PUBLISH} > checksums.txt


### PR DESCRIPTION
The upstream release pipeline does not tag the source until the build and
tests have successfully completed. This should allow for our release builds
to pick up the knative infra TAG environment variable when building releases.

Signed-off-by: Lance Ball <lball@redhat.com>

