### PR TITLE
Update installing_cli.md

### DIFF
--- a/docs/installing_cli.md
+++ b/docs/installing_cli.md
@@ -23,3 +23,5 @@ make
 mv func /usr/local/bin/
 ```
 
+## Integration with `kn`
+See [plugins](https://github.com/knative/client/blob/main/docs/README.md#plugin-configuration) section of `kn`


### PR DESCRIPTION
# Changes
Add reference for kn plugins. Specifically, plugins need a `kn-` prefix to be detected by `kn`.
