### PR TITLE
src: error-less ctors

### DIFF
--- a/client_int_test.go
+++ b/client_int_test.go
@@ -206,10 +206,7 @@ func newClient(verbose bool) *fn.Client {
 	builder := buildpacks.NewBuilder()
 	builder.Verbose = verbose
 
-	pusher, err := docker.NewPusher()
-	if err != nil {
-		panic(err)
-	}
+	pusher := docker.NewPusher()
 	pusher.Verbose = verbose
 
 	deployer := knative.NewDeployer(DefaultNamespace)

--- a/client_int_test.go
+++ b/client_int_test.go
@@ -59,10 +59,8 @@ func TestList(t *testing.T) {
 	verbose := true
 
 	// Assemble
-	lister, err := knative.NewLister(DefaultNamespace)
-	if err != nil {
-		t.Fatal(err)
-	}
+	lister := knative.NewLister(DefaultNamespace)
+
 	client := fn.New(
 		fn.WithLister(lister),
 		fn.WithVerbose(verbose))
@@ -214,22 +212,13 @@ func newClient(verbose bool) *fn.Client {
 	}
 	pusher.Verbose = verbose
 
-	deployer, err := knative.NewDeployer(DefaultNamespace)
-	if err != nil {
-		panic(err) // TODO: remove error from deployer constructor
-	}
+	deployer := knative.NewDeployer(DefaultNamespace)
 	deployer.Verbose = verbose
 
-	remover, err := knative.NewRemover(DefaultNamespace)
-	if err != nil {
-		panic(err) // TODO: remove error from remover constructor
-	}
+	remover := knative.NewRemover(DefaultNamespace)
 	remover.Verbose = verbose
 
-	lister, err := knative.NewLister(DefaultNamespace)
-	if err != nil {
-		panic(err) // TODO: remove error from lister constructor
-	}
+	lister := knative.NewLister(DefaultNamespace)
 	lister.Verbose = verbose
 
 	return fn.New(

--- a/cmd/build.go
+++ b/cmd/build.go
@@ -25,20 +25,16 @@ func newBuildClient(cfg buildConfig) (*fn.Client, error) {
 
 	var (
 		pusher *docker.Pusher
-		err    error
 	)
 	if cfg.Push {
 		credentialsProvider := creds.NewCredentialsProvider(
 			creds.WithPromptForCredentials(newPromptForCredentials()),
 			creds.WithPromptForCredentialStore(newPromptForCredentialStore()),
 			creds.WithTransport(cfg.Transport))
-		pusher, err = docker.NewPusher(
+		pusher = docker.NewPusher(
 			docker.WithCredentialsProvider(credentialsProvider),
 			docker.WithProgressListener(listener),
 			docker.WithTransport(cfg.Transport))
-		if err != nil {
-			return nil, err
-		}
 		pusher.Verbose = cfg.Verbose
 	}
 

--- a/cmd/completion_util.go
+++ b/cmd/completion_util.go
@@ -15,11 +15,8 @@ import (
 )
 
 func CompleteFunctionList(cmd *cobra.Command, args []string, toComplete string) (strings []string, directive cobra.ShellCompDirective) {
-	lister, err := knative.NewLister("")
-	if err != nil {
-		directive = cobra.ShellCompDirectiveError
-		return
-	}
+	lister := knative.NewLister("")
+
 	list, err := lister.List(cmd.Context())
 	if err != nil {
 		directive = cobra.ShellCompDirectiveError

--- a/cmd/delete.go
+++ b/cmd/delete.go
@@ -20,16 +20,10 @@ import (
 // mocking the remover or the client itself to fabricate test states.
 func newDeleteClient(cfg deleteConfig) (*fn.Client, error) {
 	listener := progress.New()
-	remover, err := knative.NewRemover(cfg.Namespace)
-	if err != nil {
-		return nil, err
-	}
+	remover := knative.NewRemover(cfg.Namespace)
 
-	pipelinesProvider, err := tekton.NewPipelinesProvider(
+	pipelinesProvider := tekton.NewPipelinesProvider(
 		tekton.WithNamespace(cfg.Namespace))
-	if err != nil {
-		return nil, err
-	}
 
 	listener.Verbose = cfg.Verbose
 	remover.Verbose = cfg.Verbose

--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -30,7 +30,6 @@ func newDeployClient(cfg deployConfig) (*fn.Client, error) {
 
 	var (
 		pusher *docker.Pusher
-		err    error
 	)
 
 	credentialsProvider := creds.NewCredentialsProvider(
@@ -39,13 +38,10 @@ func newDeployClient(cfg deployConfig) (*fn.Client, error) {
 		creds.WithTransport(cfg.Transport))
 
 	if cfg.Push {
-		pusher, err = docker.NewPusher(
+		pusher = docker.NewPusher(
 			docker.WithCredentialsProvider(credentialsProvider),
 			docker.WithProgressListener(listener),
 			docker.WithTransport(cfg.Transport))
-		if err != nil {
-			return nil, err
-		}
 		pusher.Verbose = cfg.Verbose
 	}
 

--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -49,18 +49,12 @@ func newDeployClient(cfg deployConfig) (*fn.Client, error) {
 		pusher.Verbose = cfg.Verbose
 	}
 
-	deployer, err := knative.NewDeployer(cfg.Namespace)
-	if err != nil {
-		return nil, err
-	}
+	deployer := knative.NewDeployer(cfg.Namespace)
 
-	pipelinesProvider, err := tekton.NewPipelinesProvider(
+	pipelinesProvider := tekton.NewPipelinesProvider(
 		tekton.WithNamespace(cfg.Namespace),
 		tekton.WithProgressListener(listener),
 		tekton.WithCredentialsProvider(credentialsProvider))
-	if err != nil {
-		return nil, err
-	}
 
 	listener.Verbose = cfg.Verbose
 	builder.Verbose = cfg.Verbose

--- a/cmd/info.go
+++ b/cmd/info.go
@@ -16,10 +16,7 @@ import (
 )
 
 func newInfoClient(cfg infoConfig) (*fn.Client, error) {
-	describer, err := knative.NewDescriber(cfg.Namespace)
-	if err != nil {
-		return nil, err
-	}
+	describer := knative.NewDescriber(cfg.Namespace)
 
 	describer.Verbose = cfg.Verbose
 

--- a/cmd/invoke.go
+++ b/cmd/invoke.go
@@ -21,10 +21,7 @@ import (
 type invokeClientFn func(invokeConfig) (*fn.Client, error)
 
 func newInvokeClient(cfg invokeConfig) (*fn.Client, error) {
-	describer, err := knative.NewDescriber(cfg.Namespace)
-	if err != nil {
-		return nil, err
-	}
+	describer := knative.NewDescriber(cfg.Namespace)
 	describer.Verbose = cfg.Verbose
 
 	return fn.New(

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -20,11 +20,7 @@ import (
 func newListClient(cfg listConfig) (*fn.Client, error) {
 	// TODO(lkingland): does an empty namespace mean all namespaces
 	// or the default namespace as defined in user's config?
-	lister, err := knative.NewLister(cfg.Namespace)
-	if err != nil {
-		return nil, err
-	}
-
+	lister := knative.NewLister(cfg.Namespace)
 	lister.Verbose = cfg.Verbose
 
 	return fn.New(

--- a/docker/pusher.go
+++ b/docker/pusher.go
@@ -24,7 +24,7 @@ import (
 	"github.com/google/go-containerregistry/pkg/v1/remote"
 )
 
-type Opt func(*Pusher) error
+type Opt func(*Pusher)
 
 type Credentials struct {
 	Username string
@@ -56,30 +56,26 @@ type Pusher struct {
 }
 
 func WithCredentialsProvider(cp CredentialsProvider) Opt {
-	return func(p *Pusher) error {
+	return func(p *Pusher) {
 		p.credentialsProvider = cp
-		return nil
 	}
 }
 
 func WithProgressListener(pl fn.ProgressListener) Opt {
-	return func(p *Pusher) error {
+	return func(p *Pusher) {
 		p.progressListener = pl
-		return nil
 	}
 }
 
 func WithTransport(transport http.RoundTripper) Opt {
-	return func(pusher *Pusher) error {
+	return func(pusher *Pusher) {
 		pusher.transport = transport
-		return nil
 	}
 }
 
 func WithPusherDockerClientFactory(dockerClientFactory PusherDockerClientFactory) Opt {
-	return func(pusher *Pusher) error {
+	return func(pusher *Pusher) {
 		pusher.dockerClientFactory = dockerClientFactory
-		return nil
 	}
 }
 
@@ -88,7 +84,7 @@ func EmptyCredentialsProvider(ctx context.Context, registry string) (Credentials
 }
 
 // NewPusher creates an instance of a docker-based image pusher.
-func NewPusher(opts ...Opt) (*Pusher, error) {
+func NewPusher(opts ...Opt) *Pusher {
 	result := &Pusher{
 		Verbose:             false,
 		credentialsProvider: EmptyCredentialsProvider,
@@ -100,13 +96,10 @@ func NewPusher(opts ...Opt) (*Pusher, error) {
 		},
 	}
 	for _, opt := range opts {
-		err := opt(result)
-		if err != nil {
-			return nil, err
-		}
+		opt(result)
 	}
 
-	return result, nil
+	return result
 }
 
 func GetRegistry(img string) (string, error) {

--- a/docker/pusher_test.go
+++ b/docker/pusher_test.go
@@ -105,12 +105,9 @@ func TestDaemonPush(t *testing.T) {
 	dockerClientFactory := func() (docker.PusherDockerClient, error) {
 		return dockerClient, nil
 	}
-	pusher, err := docker.NewPusher(
+	pusher := docker.NewPusher(
 		docker.WithCredentialsProvider(testCredProvider),
 		docker.WithPusherDockerClientFactory(dockerClientFactory))
-	if err != nil {
-		t.Fatal(err)
-	}
 
 	f := fn.Function{
 		Image: functionImageLocal,
@@ -185,13 +182,10 @@ func TestNonDaemonPush(t *testing.T) {
 		return dockerClient, nil
 	}
 
-	pusher, err := docker.NewPusher(
+	pusher := docker.NewPusher(
 		docker.WithTransport(transport),
 		docker.WithCredentialsProvider(testCredProvider),
 		docker.WithPusherDockerClientFactory(dockerClientFactory))
-	if err != nil {
-		t.Fatal(err)
-	}
 
 	f := fn.Function{
 		Image: functionImageRemote,

--- a/knative/deployer.go
+++ b/knative/deployer.go
@@ -36,14 +36,10 @@ type Deployer struct {
 	Verbose bool
 }
 
-func NewDeployer(namespaceOverride string) (deployer *Deployer, err error) {
-	deployer = &Deployer{}
-	namespace, err := k8s.GetNamespace(namespaceOverride)
-	if err != nil {
-		return
+func NewDeployer(namespaceOverride string) *Deployer {
+	return &Deployer{
+		Namespace: namespaceOverride,
 	}
-	deployer.Namespace = namespace
-	return
 }
 
 // Checks the status of the "user-container" for the ImagePullBackOff reason meaning that
@@ -77,6 +73,12 @@ func (d *Deployer) isImageInPrivateRegistry(ctx context.Context, client clientse
 }
 
 func (d *Deployer) Deploy(ctx context.Context, f fn.Function) (result fn.DeploymentResult, err error) {
+	if d.Namespace == "" {
+		d.Namespace, err = k8s.GetNamespace(d.Namespace)
+		if err != nil {
+			return fn.DeploymentResult{}, err
+		}
+	}
 
 	client, err := NewServingClient(d.Namespace)
 	if err != nil {

--- a/knative/describer.go
+++ b/knative/describer.go
@@ -16,15 +16,10 @@ type Describer struct {
 	namespace string
 }
 
-func NewDescriber(namespaceOverride string) (describer *Describer, err error) {
-	describer = &Describer{}
-	namespace, err := k8s.GetNamespace(namespaceOverride)
-	if err != nil {
-		return
+func NewDescriber(namespaceOverride string) *Describer {
+	return &Describer{
+		namespace: namespaceOverride,
 	}
-
-	describer.namespace = namespace
-	return
 }
 
 // Describe by name. Note that the consuming API uses domain style notation, whereas Kubernetes
@@ -32,6 +27,12 @@ func NewDescriber(namespaceOverride string) (describer *Describer, err error) {
 // detal proper full names have to be escaped on the way in and unescaped on the way out. ex:
 // www.example-site.com -> www-example--site-com
 func (d *Describer) Describe(ctx context.Context, name string) (description fn.Instance, err error) {
+	if d.namespace == "" {
+		d.namespace, err = k8s.GetNamespace(d.namespace)
+		if err != nil {
+			return fn.Instance{}, err
+		}
+	}
 
 	servingClient, err := NewServingClient(d.namespace)
 	if err != nil {

--- a/knative/lister.go
+++ b/knative/lister.go
@@ -17,19 +17,19 @@ type Lister struct {
 	Namespace string
 }
 
-func NewLister(namespaceOverride string) (l *Lister, err error) {
-	l = &Lister{}
-
-	namespace, err := k8s.GetNamespace(namespaceOverride)
-	if err != nil {
-		return
+func NewLister(namespaceOverride string) *Lister {
+	return &Lister{
+		Namespace: namespaceOverride,
 	}
-	l.Namespace = namespace
-
-	return
 }
 
 func (l *Lister) List(ctx context.Context) (items []fn.ListItem, err error) {
+	if l.Namespace == "" {
+		l.Namespace, err = k8s.GetNamespace(l.Namespace)
+		if err != nil {
+			return nil, err
+		}
+	}
 
 	client, err := NewServingClient(l.Namespace)
 	if err != nil {

--- a/knative/remover.go
+++ b/knative/remover.go
@@ -10,15 +10,10 @@ import (
 
 const RemoveTimeout = 120 * time.Second
 
-func NewRemover(namespaceOverride string) (remover *Remover, err error) {
-	remover = &Remover{}
-	namespace, err := k8s.GetNamespace(namespaceOverride)
-	if err != nil {
-		return
+func NewRemover(namespaceOverride string) *Remover {
+	return &Remover{
+		Namespace: namespaceOverride,
 	}
-	remover.Namespace = namespace
-
-	return
 }
 
 type Remover struct {
@@ -27,6 +22,12 @@ type Remover struct {
 }
 
 func (remover *Remover) Remove(ctx context.Context, name string) (err error) {
+	if remover.Namespace == "" {
+		remover.Namespace, err = k8s.GetNamespace(remover.Namespace)
+		if err != nil {
+			return err
+		}
+	}
 
 	client, err := NewServingClient(remover.Namespace)
 	if err != nil {


### PR DESCRIPTION
Constructors do only necessary initialization with no possible error.
Errors are deferred until some actual operation is being done.

This allows to initialize all parts of `fn.Client` at once with no error.
We need this to be able to create a shared factory function of `fn.Client` for multiple commands.
Without this such a factory is not possible because the function could fail while initializing something that won't be actually used.
For example: `func create` doesn't need `k8s` configuration set up, but the command would still fail because of it.