### PR TITLE
Single common `fn.Client` factory for all commands

### DIFF
--- a/cmd/client.go
+++ b/cmd/client.go
@@ -1,0 +1,87 @@
+package cmd
+
+import (
+	"net/http"
+
+	fn "knative.dev/kn-plugin-func"
+	"knative.dev/kn-plugin-func/buildpacks"
+	"knative.dev/kn-plugin-func/docker"
+	"knative.dev/kn-plugin-func/docker/creds"
+	"knative.dev/kn-plugin-func/knative"
+	"knative.dev/kn-plugin-func/pipelines/tekton"
+	"knative.dev/kn-plugin-func/progress"
+)
+
+type ClientOptions struct {
+	Namespace    string
+	Registry     string
+	Repository   string
+	Repositories string
+	Verbose      bool
+}
+
+type ClientFactory func(opts ClientOptions) *fn.Client
+
+func NewClientFactory(transport http.RoundTripper) ClientFactory {
+	return func(clientOptions ClientOptions) *fn.Client {
+		builder := buildpacks.NewBuilder()
+		builder.Verbose = clientOptions.Verbose
+
+		progressListener := progress.New()
+		progressListener.Verbose = clientOptions.Verbose
+
+		credentialsProvider := creds.NewCredentialsProvider(
+			creds.WithPromptForCredentials(newPromptForCredentials()),
+			creds.WithPromptForCredentialStore(newPromptForCredentialStore()),
+			creds.WithTransport(transport))
+
+		pusher := docker.NewPusher(
+			docker.WithCredentialsProvider(credentialsProvider),
+			docker.WithProgressListener(progressListener),
+			docker.WithTransport(transport))
+		pusher.Verbose = clientOptions.Verbose
+
+		deployer := knative.NewDeployer(clientOptions.Namespace)
+		deployer.Verbose = clientOptions.Verbose
+
+		pipelinesProvider := tekton.NewPipelinesProvider(
+			tekton.WithNamespace(clientOptions.Namespace),
+			tekton.WithProgressListener(progressListener),
+			tekton.WithCredentialsProvider(credentialsProvider))
+		pipelinesProvider.Verbose = clientOptions.Verbose
+
+		remover := knative.NewRemover(clientOptions.Namespace)
+		remover.Verbose = clientOptions.Verbose
+
+		describer := knative.NewDescriber(clientOptions.Namespace)
+		describer.Verbose = clientOptions.Verbose
+
+		lister := knative.NewLister(clientOptions.Namespace)
+		lister.Verbose = clientOptions.Verbose
+
+		runner := docker.NewRunner()
+		runner.Verbose = clientOptions.Verbose
+
+		opts := []fn.Option{
+			fn.WithRepository(clientOptions.Repository), // URI of repository override
+			fn.WithRegistry(clientOptions.Registry),
+			fn.WithVerbose(clientOptions.Verbose),
+			fn.WithTransport(transport),
+			fn.WithProgressListener(progressListener),
+			fn.WithBuilder(builder),
+			fn.WithPipelinesProvider(pipelinesProvider),
+			fn.WithRemover(remover),
+			fn.WithDescriber(describer),
+			fn.WithLister(lister),
+			fn.WithRunner(runner),
+			fn.WithDeployer(deployer),
+			fn.WithPusher(pusher),
+		}
+
+		if clientOptions.Repositories != "" {
+			opts = append(opts, fn.WithRepositories(clientOptions.Repositories)) // path to repositories in disk
+		}
+
+		return fn.New(opts...)
+	}
+}

--- a/cmd/create_test.go
+++ b/cmd/create_test.go
@@ -18,7 +18,7 @@ func TestCreate_Execute(t *testing.T) {
 	defer fromTempDir(t)()
 
 	// command with a client factory which yields a fully default client.
-	cmd := NewCreateCmd(func(createConfig) *fn.Client { return fn.New() })
+	cmd := NewCreateCmd(func(ClientOptions) *fn.Client { return fn.New() })
 	cmd.SetArgs([]string{
 		fmt.Sprintf("--language=%s", "go"),
 	})
@@ -34,7 +34,7 @@ func TestCreate_NoRuntime(t *testing.T) {
 	defer fromTempDir(t)()
 
 	// command with a client factory which yields a fully default client.
-	cmd := NewCreateCmd(func(createConfig) *fn.Client { return fn.New() })
+	cmd := NewCreateCmd(func(ClientOptions) *fn.Client { return fn.New() })
 	cmd.SetArgs([]string{})
 
 	err := cmd.Execute()
@@ -50,7 +50,7 @@ func TestCreate_WithInvalidRuntime(t *testing.T) {
 	defer fromTempDir(t)()
 
 	// command with a client factory which yields a fully default client.
-	cmd := NewCreateCmd(func(createConfig) *fn.Client { return fn.New() })
+	cmd := NewCreateCmd(func(ClientOptions) *fn.Client { return fn.New() })
 	cmd.SetArgs([]string{
 		fmt.Sprintf("--language=%s", "test"),
 	})
@@ -68,7 +68,7 @@ func TestCreate_InvalidTemplate(t *testing.T) {
 	defer fromTempDir(t)()
 
 	// command with a client factory which yields a fully default client.
-	cmd := NewCreateCmd(func(createConfig) *fn.Client { return fn.New() })
+	cmd := NewCreateCmd(func(ClientOptions) *fn.Client { return fn.New() })
 	cmd.SetArgs([]string{
 		fmt.Sprintf("--language=%s", "go"),
 		fmt.Sprintf("--template=%s", "events"),
@@ -88,7 +88,7 @@ func TestCreate_ValidatesName(t *testing.T) {
 
 	// Create a new Create command with a fn.Client construtor
 	// which returns a default (noop) client suitable for tests.
-	cmd := NewCreateCmd(func(createConfig) *fn.Client { return fn.New() })
+	cmd := NewCreateCmd(func(ClientOptions) *fn.Client { return fn.New() })
 
 	// Execute the command with a function name containing invalid characters and
 	// confirm the expected error is returned
@@ -121,7 +121,7 @@ func TestCreate_RepositoriesPath(t *testing.T) {
 	// after flags, environment variables, etc. are calculated.  In this case it
 	// will validate the test condition:  that config reflects the value of
 	// XDG_CONFIG_HOME, and secondarily the path suffix `func/repositories`.
-	cmd := NewCreateCmd(func(cfg createConfig) *fn.Client {
+	cmd := NewCreateCmd(func(cfg ClientOptions) *fn.Client {
 		if cfg.Repositories != expected {
 			t.Fatalf("expected repositories default path to be '%v', got '%v'", expected, cfg.Repositories)
 		}

--- a/cmd/delete_test.go
+++ b/cmd/delete_test.go
@@ -28,8 +28,8 @@ func TestDelete_ByName(t *testing.T) {
 
 	// Create a command with a client constructor fn that instantiates a client
 	// with a the mocked remover.
-	cmd := NewDeleteCmd(func(_ deleteConfig) (*fn.Client, error) {
-		return fn.New(fn.WithRemover(remover)), nil
+	cmd := NewDeleteCmd(func(ClientOptions) *fn.Client {
+		return fn.New(fn.WithRemover(remover))
 	})
 
 	// Execute the command
@@ -80,8 +80,8 @@ created: 2021-01-01T00:00:00+00:00
 
 	// Command with a Client constructor that returns  client with the
 	// mocked remover.
-	cmd := NewDeleteCmd(func(_ deleteConfig) (*fn.Client, error) {
-		return fn.New(fn.WithRemover(remover)), nil
+	cmd := NewDeleteCmd(func(ClientOptions) *fn.Client {
+		return fn.New(fn.WithRemover(remover))
 	})
 
 	// Execute the command simulating no arguments.
@@ -108,8 +108,8 @@ func TestDelete_NameAndPathExclusivity(t *testing.T) {
 	remover := mock.NewRemover()
 
 	// Command with a Client constructor using the mock remover.
-	cmd := NewDeleteCmd(func(_ deleteConfig) (*fn.Client, error) {
-		return fn.New(fn.WithRemover(remover)), nil
+	cmd := NewDeleteCmd(func(ClientOptions) *fn.Client {
+		return fn.New(fn.WithRemover(remover))
 	})
 
 	// Execute the command simulating the invalid argument combination of both


### PR DESCRIPTION
Added single common factory function of `fn.Client` for all commands.
This allows to set all important settings at one place.