### PR TITLE
Update guide for podman

### DIFF
--- a/docs/guides/podman.md
+++ b/docs/guides/podman.md
@@ -2,7 +2,7 @@
 
 Under Linux, it is possible to use [podman](https://podman.io/) instead of [docker](https://www.docker.com/). With Functions, you'll need `podman` version `v3.3` or better for this to work properly.
 
-For `func` version `v0.20.0` and latter no further setup should be needed,
+For `func` version `v0.20.0` and later no further setup is needed,
 `func` should use `podman` automatically.
 
 For older versions some setup is required:

--- a/docs/guides/podman.md
+++ b/docs/guides/podman.md
@@ -2,6 +2,11 @@
 
 Under Linux, it is possible to use [podman](https://podman.io/) instead of [docker](https://www.docker.com/). With Functions, you'll need `podman` version `v3.3` or better for this to work properly.
 
+For `func` version `v0.20.0` and latter no further setup should be needed,
+`func` should use `podman` automatically.
+
+For older versions some setup is required:
+
 In order to do this you need to run `podman` as a service. You can do this with the following command.
 ```
 ❯ systemctl start --user podman.socket


### PR DESCRIPTION
In the newer versions of `func` there is no need for starting the service and setting the `DOCKER_HOST` envvar.
It should be handled automatically.