### PR TITLE
chore: accommodate knative's go linter

### DIFF
--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -197,7 +197,10 @@ func TestVerbose(t *testing.T) {
 
 			cmd.SetArgs(tt.args)
 			cmd.SetOut(&out)
-			cmd.Execute()
+			err = cmd.Execute()
+			if err != nil {
+				t.Fatal(err)
+			}
 
 			if out.String() != tt.want {
 				t.Errorf("expected output: %q but got: %q", tt.want, out.String())


### PR DESCRIPTION
# Changes

- :broom: check the possible error returned from `cmd.Execute()` in root_test.go in order to satisfy linting and fix CI

/kind cleanup
