### PR TITLE
Adding sample function in go template

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,7 +7,7 @@
 /coverage.out
 /bin
 /target
-
+.DS_Store
 node_modules
 __pycache__
 /coverage.out

--- a/templates/go/cloudevents/README.md
+++ b/templates/go/cloudevents/README.md
@@ -1,6 +1,6 @@
 # Go Cloud Events Function
 
-Welcome to your new Go Function! The boilerplate function code can be found in [`handle.go`](handle.go). This Function is meant to respond exclusively to [Cloud Events](https://cloudevents.io/), but you can remove the check for this in the function and it will respond just fine to plain vanilla incoming HTTP requests. 
+Welcome to your new Go Function! The boilerplate function code can be found in [`handle.go`](handle.go). This Function is meant to respond exclusively to [Cloud Events](https://cloudevents.io/), but you can remove the check for this in the function and it will respond just fine to plain vanilla incoming HTTP requests.
 
 ## Development
 
@@ -9,13 +9,14 @@ Develop new features by adding a test to [`handle_test.go`](handle_test.go) for 
 Update the running analog of the function using the `func` CLI or client library, and it can be invoked using a manually-created CloudEvent:
 
 ```console
-curl -X POST -d '{"hello": "world"}' \
+curl -v -X POST -d '{"input": "hello"}' \
   -H'Content-type: application/json' \
   -H'Ce-id: 1' \
   -H'Ce-source: cloud-event-example' \
-  -H'Ce-type: dev.knative.example' \
+  -H'Ce-subject: Convert to UpperCase' \
+  -H'Ce-type: UppercaseRequestedEvent' \
   -H'Ce-specversion: 1.0' \
-  http://myFunction.example.com/
+  http://localhost:8080/
 ```
 
 For more, see [the complete documentation]('https://github.com/knative-sandbox/kn-plugin-func/tree/main/docs')

--- a/templates/go/cloudevents/README.md
+++ b/templates/go/cloudevents/README.md
@@ -9,12 +9,12 @@ Develop new features by adding a test to [`handle_test.go`](handle_test.go) for 
 Update the running analog of the function using the `func` CLI or client library, and it can be invoked using a manually-created CloudEvent:
 
 ```console
-curl -v -X POST -d '{"input": "hello"}' \
+curl -v -X POST -d 'hello' \
   -H'Content-type: application/json' \
   -H'Ce-id: 1' \
   -H'Ce-source: cloud-event-example' \
-  -H'Ce-subject: Convert to UpperCase' \
-  -H'Ce-type: UppercaseRequestedEvent' \
+  -H'Ce-subject: Echo content' \
+  -H'Ce-type: MyEvent' \
   -H'Ce-specversion: 1.0' \
   http://localhost:8080/
 ```

--- a/templates/go/cloudevents/handle.go
+++ b/templates/go/cloudevents/handle.go
@@ -3,56 +3,39 @@ package function
 import (
 	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
-	"strings"
 
 	"github.com/cloudevents/sdk-go/v2/event"
 
 	cloudevents "github.com/cloudevents/sdk-go/v2"
 )
 
-type Output struct {
-	Output    string `json:"output"`
-	Input     string `json:"input"`
-	Operation string `json:"operation"`
-}
+// Handle an event.
+func Handle(ctx context.Context, event cloudevents.Event) (*event.Event, error) {
 
-type Input struct {
-	Input string `json:"input"`
-}
+	/*
+	 * YOUR CODE HERE
+	 *
+	 * Try running `go test`.  Add more test as you code in `handle_test.go`.
+	 */
 
-func uppercase(event cloudevents.Event) (*event.Event, error) {
-	input := Input{}
-	err := json.Unmarshal(event.Data(), &input)
+	fmt.Printf("Incoming Event: %v\n", event) // print the received event to standard output
+	payload := ""
+	err := json.Unmarshal(event.Data(), &payload)
 	if err != nil {
 		fmt.Printf("%v\n", err)
 		return nil, err
 	}
-	fmt.Printf("%v\n", input)
+
+	payload = "echo " + payload
 	outputEvent := cloudevents.NewEvent()
-	outputEvent.SetSource("http://example.com/uppercase")
-	outputEvent.SetType("UpperCasedEvent")
-	output := Output{}
-	output.Input = input.Input
-	output.Output = strings.ToUpper(input.Input)
-	output.Operation = event.Subject()
-	outputEvent.SetData(cloudevents.ApplicationJSON, &output)
+	outputEvent.SetSource("http://example.com/echo")
+	outputEvent.SetType("Echo")
+	outputEvent.SetData(cloudevents.ApplicationJSON, &payload)
 
 	fmt.Printf("Outgoing Event: %v\n", outputEvent)
 
 	return &outputEvent, nil
-}
-
-// Handle an event.
-func Handle(ctx context.Context, event cloudevents.Event) (*event.Event, error) {
-
-	// Example implementation:
-	fmt.Printf("Incoming Event: %v\n", event) // print the received event to standard output
-	if event.Type() == "uppercase" {
-		return uppercase(event)
-	}
-	return nil, errors.New("No action for event type: " + event.Type())
 }
 
 /*

--- a/templates/go/cloudevents/handle.go
+++ b/templates/go/cloudevents/handle.go
@@ -2,24 +2,57 @@ package function
 
 import (
 	"context"
+	"encoding/json"
+	"errors"
 	"fmt"
+	"strings"
 
-	event "github.com/cloudevents/sdk-go/v2"
+	"github.com/cloudevents/sdk-go/v2/event"
+
+	cloudevents "github.com/cloudevents/sdk-go/v2"
 )
 
-// Handle an event.
-func Handle(ctx context.Context, event event.Event) error {
+type Output struct {
+	Output    string `json:"output"`
+	Input     string `json:"input"`
+	Operation string `json:"operation"`
+}
 
-	/*
-	 * YOUR CODE HERE
-	 *
-	 * Try running `go test`.  Add more test as you code in `handle_test.go`.
-	 */
+type Input struct {
+	Input string `json:"input"`
+}
+
+func uppercase(event cloudevents.Event) (*event.Event, error) {
+	input := Input{}
+	err := json.Unmarshal(event.Data(), &input)
+	if err != nil {
+		fmt.Printf("%v\n", err)
+		return nil, err
+	}
+	fmt.Printf("%v\n", input)
+	outputEvent := cloudevents.NewEvent()
+	outputEvent.SetSource("http://example.com/uppercase")
+	outputEvent.SetType("UpperCasedEvent")
+	output := Output{}
+	output.Input = input.Input
+	output.Output = strings.ToUpper(input.Input)
+	output.Operation = event.Subject()
+	outputEvent.SetData(cloudevents.ApplicationJSON, &output)
+
+	fmt.Printf("Outgoing Event: %v\n", outputEvent)
+
+	return &outputEvent, nil
+}
+
+// Handle an event.
+func Handle(ctx context.Context, event cloudevents.Event) (*event.Event, error) {
 
 	// Example implementation:
-	fmt.Printf("%v\n", event) // print the received event to standard output
-
-	return nil
+	fmt.Printf("Incoming Event: %v\n", event) // print the received event to standard output
+	if event.Type() == "uppercase" {
+		return uppercase(event)
+	}
+	return nil, errors.New("No action for event type: " + event.Type())
 }
 
 /*

--- a/templates/go/cloudevents/handle_test.go
+++ b/templates/go/cloudevents/handle_test.go
@@ -3,7 +3,6 @@ package function
 import (
 	"context"
 	"encoding/json"
-	"strings"
 	"testing"
 
 	cloudevents "github.com/cloudevents/sdk-go/v2"
@@ -16,11 +15,10 @@ func TestHandle(t *testing.T) {
 	// A minimal, but valid, event.
 	event := event.New()
 	event.SetID("TEST-EVENT-01")
-	event.SetType("UppercaseRequestedEvent")
+	event.SetType("MyEvent")
 	event.SetSource("http://localhost:8080/")
-	event.SetSubject("Convert to UpperCase")
-	input := Input{}
-	input.Input = "hello"
+	event.SetSubject("Echo")
+	input := "hello"
 	event.SetData(cloudevents.ApplicationJSON, &input)
 	// Invoke the defined handler.
 	ce, err := Handle(context.Background(), event)
@@ -31,22 +29,16 @@ func TestHandle(t *testing.T) {
 	if ce == nil {
 		t.Errorf("The output CloudEvent cannot be nil")
 	}
-	if ce.Type() != "UpperCasedEvent" {
-		t.Errorf("Wrong CloudEvent Type received: %v , expected UpperCasedEvent", ce.Type())
+	if ce.Type() != "Echo" {
+		t.Errorf("Wrong CloudEvent Type received: %v , expected Echo", ce.Type())
 	}
-	output := Output{}
+	output := ""
 	err = json.Unmarshal(ce.Data(), &output)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if output.Operation != event.Subject() {
-		t.Errorf("The output.Operation: %v should be the same as the input event Subject: %v", output.Operation, event.Subject())
-	}
-	if output.Input != input.Input {
-		t.Errorf("The output.Input: %v should be the same as the input.Input: %v", output.Input, input.Input)
+	if output != "echo "+input {
+		t.Errorf("The expected output should be: 'echo hello and it was: %v", output)
 	}
 
-	if output.Output != strings.ToUpper(input.Input) {
-		t.Errorf("The output.Output: %v should be the same as the input.Input in uppercase: %v", output.Output, strings.ToUpper(input.Input))
-	}
 }

--- a/templates/go/cloudevents/handle_test.go
+++ b/templates/go/cloudevents/handle_test.go
@@ -2,7 +2,11 @@ package function
 
 import (
 	"context"
+	"encoding/json"
+	"strings"
 	"testing"
+
+	cloudevents "github.com/cloudevents/sdk-go/v2"
 
 	"github.com/cloudevents/sdk-go/v2/event"
 )
@@ -12,11 +16,37 @@ func TestHandle(t *testing.T) {
 	// A minimal, but valid, event.
 	event := event.New()
 	event.SetID("TEST-EVENT-01")
-	event.SetType("com.example.event.test")
+	event.SetType("UppercaseRequestedEvent")
 	event.SetSource("http://localhost:8080/")
-
+	event.SetSubject("Convert to UpperCase")
+	input := Input{}
+	input.Input = "hello"
+	event.SetData(cloudevents.ApplicationJSON, &input)
 	// Invoke the defined handler.
-	if err := Handle(context.Background(), event); err != nil {
+	ce, err := Handle(context.Background(), event)
+	if err != nil {
 		t.Fatal(err)
+	}
+
+	if ce == nil {
+		t.Errorf("The output CloudEvent cannot be nil")
+	}
+	if ce.Type() != "UpperCasedEvent" {
+		t.Errorf("Wrong CloudEvent Type received: %v , expected UpperCasedEvent", ce.Type())
+	}
+	output := Output{}
+	err = json.Unmarshal(ce.Data(), &output)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if output.Operation != event.Subject() {
+		t.Errorf("The output.Operation: %v should be the same as the input event Subject: %v", output.Operation, event.Subject())
+	}
+	if output.Input != input.Input {
+		t.Errorf("The output.Input: %v should be the same as the input.Input: %v", output.Input, input.Input)
+	}
+
+	if output.Output != strings.ToUpper(input.Input) {
+		t.Errorf("The output.Output: %v should be the same as the input.Input in uppercase: %v", output.Output, strings.ToUpper(input.Input))
 	}
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

# Changes

Fixes #839 

- :broom: function template uses signature which expects a CloudEvent and returns a CloudEvent
- :broom: add example function to go template, this function uses the same events as the spring-boot template
- :broom: test added to check correct events and payloads

/kind enhancement
