### PR TITLE
added git related flags for remote builds

### DIFF
--- a/client.go
+++ b/client.go
@@ -692,7 +692,7 @@ func (c *Client) Deploy(ctx context.Context, path string) (err error) {
 }
 
 // RunPipeline runs a Pipeline to Build and deploy the Function at path.
-func (c *Client) RunPipeline(ctx context.Context, path string) (err error) {
+func (c *Client) RunPipeline(ctx context.Context, path string, git Git) (err error) {
 	go func() {
 		<-ctx.Done()
 		c.progressListener.Stopping()
@@ -702,6 +702,7 @@ func (c *Client) RunPipeline(ctx context.Context, path string) (err error) {
 	if err != nil {
 		return
 	}
+	f.Git = git
 
 	// Build and deploy function using Pipeline
 	err = c.pipelinesProvider.Run(ctx, f)

--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -166,7 +166,7 @@ func runDeploy(cmd *cobra.Command, _ []string, newClient ClientFactory) (err err
 	switch currentBuildType {
 	case fn.BuildTypeLocal, "":
 		if config.GitURL != "" || config.GitDir != "" || config.GitBranch != "" {
-			return fmt.Errorf("remote git arguments require the --build=remote flag")
+			return fmt.Errorf("remote git arguments require the --build=git flag")
 		}
 		if err := client.Build(cmd.Context(), config.Path); err != nil {
 			return err

--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -51,13 +51,16 @@ kn func deploy --registry quay.io/myuser
 kn func deploy --image quay.io/myuser/myfunc -n myns
 `,
 		SuggestFor: []string{"delpoy", "deplyo"},
-		PreRunE:    bindEnv("image", "namespace", "path", "registry", "confirm", "build", "push"),
+		PreRunE:    bindEnv("image", "namespace", "path", "registry", "confirm", "build", "push", "git-url", "git-branch", "git-dir"),
 	}
 
 	cmd.Flags().BoolP("confirm", "c", false, "Prompt to confirm all configuration options (Env: $FUNC_CONFIRM)")
 	cmd.Flags().StringArrayP("env", "e", []string{}, "Environment variable to set in the form NAME=VALUE. "+
 		"You may provide this flag multiple times for setting multiple environment variables. "+
 		"To unset, specify the environment variable name followed by a \"-\" (e.g., NAME-).")
+	cmd.Flags().StringP("git-url", "g", "", "Repo url to push the code to be built")
+	cmd.Flags().StringP("git-branch", "t", "", "Git branch to be used for remote builds")
+	cmd.Flags().StringP("git-dir", "d", "", "Directory in the repo where the function is located")
 	cmd.Flags().StringP("image", "i", "", "Full image name in the form [registry]/[namespace]/[name]:[tag] (optional). This option takes precedence over --registry (Env: $FUNC_IMAGE)")
 	cmd.Flags().StringP("registry", "r", "", "Registry + namespace part of the image to build, ex 'quay.io/myuser'.  The full image name is automatically determined based on the local directory name. If not provided the registry will be taken from func.yaml (Env: $FUNC_REGISTRY)")
 	cmd.Flags().StringP("build", "b", fn.DefaultBuildType, fmt.Sprintf("Build specifies the way the function should be built. Supported types are %s (Env: $FUNC_BUILD)", fn.SupportedBuildTypes(true)))
@@ -107,13 +110,6 @@ func runDeploy(cmd *cobra.Command, _ []string, newClient ClientFactory) (err err
 		err = validateBuildType(config.BuildType)
 		if err != nil {
 			return err
-		}
-
-		// update function config if build type has been changed
-		// don't store type `disabled` as it should be used only as a parameter in `func deploy`
-		// and not stored in function config
-		if function.BuildType != config.BuildType && config.BuildType != fn.BuildTypeDisabled {
-			function.BuildType = config.BuildType
 		}
 	} else {
 		currentBuildType = function.BuildType
@@ -173,7 +169,21 @@ func runDeploy(cmd *cobra.Command, _ []string, newClient ClientFactory) (err err
 			return err
 		}
 	case fn.BuildTypeGit:
-		return client.RunPipeline(cmd.Context(), config.Path)
+		git := function.Git
+
+		if config.GitURL != "" {
+			git.URL = &config.GitURL
+		}
+
+		if config.GitBranch != "" {
+			git.Revision = &config.GitBranch
+		}
+
+		if config.GitDir != "" {
+			git.ContextDir = &config.GitDir
+		}
+
+		return client.RunPipeline(cmd.Context(), config.Path, git)
 	case fn.BuildTypeDisabled:
 		// nothing needed to be done for `build=disabled`
 	default:
@@ -282,6 +292,15 @@ type deployConfig struct {
 
 	// Envs passed via cmd to removed
 	EnvToRemove []string
+
+	// Git repo url for remote builds
+	GitURL string
+
+	// Git branch for remote builds
+	GitBranch string
+
+	// Directory in the git repo where the function is located
+	GitDir string
 }
 
 // newDeployConfig creates a buildConfig populated from command flags and
@@ -309,6 +328,9 @@ func newDeployConfig(cmd *cobra.Command) (deployConfig, error) {
 		Push:        viper.GetBool("push"),
 		EnvToUpdate: envToUpdate,
 		EnvToRemove: envToRemove,
+		GitURL:      viper.GetString("git-url"),
+		GitBranch:   viper.GetString("git-branch"),
+		GitDir:      viper.GetString("git-dir"),
 	}, nil
 }
 

--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -173,6 +173,11 @@ func runDeploy(cmd *cobra.Command, _ []string, newClient ClientFactory) (err err
 
 		if config.GitURL != "" {
 			git.URL = &config.GitURL
+			if strings.Contains(config.GitURL, "#") {
+				parts := strings.Split(config.GitURL, "#")
+				git.URL = &parts[0]
+				git.Revision = &parts[1]
+			}
 		}
 
 		if config.GitBranch != "" {

--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -58,9 +58,9 @@ kn func deploy --image quay.io/myuser/myfunc -n myns
 	cmd.Flags().StringArrayP("env", "e", []string{}, "Environment variable to set in the form NAME=VALUE. "+
 		"You may provide this flag multiple times for setting multiple environment variables. "+
 		"To unset, specify the environment variable name followed by a \"-\" (e.g., NAME-).")
-	cmd.Flags().StringP("git-url", "g", "", "Repo url to push the code to be built")
-	cmd.Flags().StringP("git-branch", "t", "", "Git branch to be used for remote builds")
-	cmd.Flags().StringP("git-dir", "d", "", "Directory in the repo where the function is located")
+	cmd.Flags().StringP("git-url", "g", "", "Repo url to push the code to be built (Env: $FUNC_GIT_URL)")
+	cmd.Flags().StringP("git-branch", "t", "", "Git branch to be used for remote builds (Env: $FUNC_GIT_BRANCH)")
+	cmd.Flags().StringP("git-dir", "d", "", "Directory in the repo where the function is located (Env: $FUNC_GIT_DIR)")
 	cmd.Flags().StringP("image", "i", "", "Full image name in the form [registry]/[namespace]/[name]:[tag] (optional). This option takes precedence over --registry (Env: $FUNC_IMAGE)")
 	cmd.Flags().StringP("registry", "r", "", "Registry + namespace part of the image to build, ex 'quay.io/myuser'.  The full image name is automatically determined based on the local directory name. If not provided the registry will be taken from func.yaml (Env: $FUNC_REGISTRY)")
 	cmd.Flags().StringP("build", "b", fn.DefaultBuildType, fmt.Sprintf("Build specifies the way the function should be built. Supported types are %s (Env: $FUNC_BUILD)", fn.SupportedBuildTypes(true)))
@@ -165,6 +165,9 @@ func runDeploy(cmd *cobra.Command, _ []string, newClient ClientFactory) (err err
 
 	switch currentBuildType {
 	case fn.BuildTypeLocal, "":
+		if config.GitURL != "" || config.GitDir != "" || config.GitBranch != "" {
+			return fmt.Errorf("remote git arguments require the --build=remote flag")
+		}
 		if err := client.Build(cmd.Context(), config.Path); err != nil {
 			return err
 		}

--- a/cmd/deploy_test.go
+++ b/cmd/deploy_test.go
@@ -40,6 +40,18 @@ created: 2009-11-10 23:00:00`,
 			expectCallContextDir: pointer.StringPtr("func"),
 		},
 		{
+			name:      "Git url gets split when in the format url#branch",
+			gitURL:    "git@github.com:knative-sandbox/kn-plugin-func.git#main",
+			gitDir:    "func",
+			buildType: fn.BuildTypeGit,
+			funcFile: `name: test-func
+runtime: go
+created: 2009-11-10 23:00:00`,
+			expectCallURL:        pointer.StringPtr("git@github.com:knative-sandbox/kn-plugin-func.git"),
+			expectCallBranch:     pointer.StringPtr("main"),
+			expectCallContextDir: pointer.StringPtr("func"),
+		},
+		{
 			name:      "Git arguments override func.yaml but don't get saved",
 			gitURL:    "git@github.com:knative-sandbox/kn-plugin-func.git",
 			gitBranch: "main",

--- a/cmd/deploy_test.go
+++ b/cmd/deploy_test.go
@@ -1,0 +1,147 @@
+package cmd
+
+import (
+	"context"
+	"os"
+	"testing"
+
+	"github.com/ory/viper"
+	"k8s.io/utils/pointer"
+	fn "knative.dev/kn-plugin-func"
+	"knative.dev/kn-plugin-func/mock"
+)
+
+func Test_runDeploy(t *testing.T) {
+	tests := []struct {
+		name                 string
+		gitURL               string
+		gitBranch            string
+		gitDir               string
+		buildType            string
+		funcFile             string
+		expectFileURL        *string
+		expectFileBranch     *string
+		expectFileContextDir *string
+		expectCallURL        *string
+		expectCallBranch     *string
+		expectCallContextDir *string
+	}{
+		{
+			name:      "Git arguments don't get saved to func.yaml but are used in the pipeline invocation",
+			gitURL:    "git@github.com:knative-sandbox/kn-plugin-func.git",
+			gitBranch: "main",
+			gitDir:    "func",
+			buildType: fn.BuildTypeGit,
+			funcFile: `name: test-func
+runtime: go
+created: 2009-11-10 23:00:00`,
+			expectCallURL:        pointer.StringPtr("git@github.com:knative-sandbox/kn-plugin-func.git"),
+			expectCallBranch:     pointer.StringPtr("main"),
+			expectCallContextDir: pointer.StringPtr("func"),
+		},
+		{
+			name:      "Git arguments override func.yaml but don't get saved",
+			gitURL:    "git@github.com:knative-sandbox/kn-plugin-func.git",
+			gitBranch: "main",
+			gitDir:    "func",
+			funcFile: `name: test-func
+runtime: go
+created: 2009-11-10 23:00:00
+build: git
+git:
+  url: git@github.com:my-repo/my-function.git
+  revision: master
+  contextDir: pwd`,
+			expectCallURL:        pointer.StringPtr("git@github.com:knative-sandbox/kn-plugin-func.git"),
+			expectCallBranch:     pointer.StringPtr("main"),
+			expectCallContextDir: pointer.StringPtr("func"),
+			expectFileURL:        pointer.StringPtr("git@github.com:my-repo/my-function.git"),
+			expectFileBranch:     pointer.StringPtr("master"),
+			expectFileContextDir: pointer.StringPtr("pwd"),
+		},
+		{
+			name: "Git properties work without arguments",
+			funcFile: `name: test-func
+runtime: go
+created: 2009-11-10 23:00:00
+build: git
+git:
+  url: git@github.com:my-repo/my-function.git
+  revision: master
+  contextDir: pwd`,
+			expectFileURL:        pointer.StringPtr("git@github.com:my-repo/my-function.git"),
+			expectFileBranch:     pointer.StringPtr("master"),
+			expectFileContextDir: pointer.StringPtr("pwd"),
+			expectCallURL:        pointer.StringPtr("git@github.com:my-repo/my-function.git"),
+			expectCallBranch:     pointer.StringPtr("master"),
+			expectCallContextDir: pointer.StringPtr("pwd"),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var captureFn fn.Function
+			pipeline := &mock.PipelinesProvider{
+				RunFn: func(f fn.Function) error {
+					captureFn = f
+					return nil
+				},
+			}
+			deployer := mock.NewDeployer()
+			defer fromTempDir(t)()
+			cmd := NewDeployCmd(func(opts ClientOptions) *fn.Client {
+				return fn.New(
+					fn.WithPipelinesProvider(pipeline),
+					fn.WithDeployer(deployer),
+				)
+			})
+
+			viper.SetDefault("git-url", tt.gitURL)
+			viper.SetDefault("git-branch", tt.gitBranch)
+			viper.SetDefault("git-dir", tt.gitDir)
+			viper.SetDefault("build", tt.buildType)
+			viper.SetDefault("registry", "docker.io/tigerteam")
+
+			// set test case's func.yaml
+			if err := os.WriteFile("func.yaml", []byte(tt.funcFile), os.ModePerm); err != nil {
+				t.Fatal(err)
+			}
+
+			ctx, _ := context.WithCancel(context.TODO())
+
+			_, err := cmd.ExecuteContextC(ctx)
+			if err != nil {
+				t.Fatalf("Problem executing command: %v", err)
+			}
+
+			fileFunction, err := fn.NewFunction(".")
+
+			if err != nil {
+				t.Fatalf("problem creating function: %v", err)
+			}
+
+			{
+				if fileURL, expectedURL := pointer.StringPtrDerefOr(fileFunction.Git.URL, ""), pointer.StringPtrDerefOr(tt.expectFileURL, ""); fileURL != expectedURL {
+					t.Fatalf("file Git URL expected to be (%v) but was (%v)", expectedURL, fileURL)
+				}
+				if fileBranch, expectedBranch := pointer.StringPtrDerefOr(fileFunction.Git.Revision, ""), pointer.StringPtrDerefOr(tt.expectFileBranch, ""); fileBranch != expectedBranch {
+					t.Fatalf("file Git branch expected to be (%v) but was (%v)", expectedBranch, fileBranch)
+				}
+				if fileDir, expectedDir := pointer.StringPtrDerefOr(fileFunction.Git.ContextDir, ""), pointer.StringPtrDerefOr(tt.expectFileContextDir, ""); fileDir != expectedDir {
+					t.Fatalf("file Git contextDir expected to be (%v) but was (%v)", expectedDir, fileDir)
+				}
+			}
+
+			{
+				if caputureURL, expectedURL := pointer.StringPtrDerefOr(captureFn.Git.URL, ""), pointer.StringPtrDerefOr(tt.expectCallURL, ""); caputureURL != expectedURL {
+					t.Fatalf("call Git URL expected to be (%v) but was (%v)", expectedURL, caputureURL)
+				}
+				if captureBranch, expectedBranch := pointer.StringPtrDerefOr(captureFn.Git.Revision, ""), pointer.StringPtrDerefOr(tt.expectCallBranch, ""); captureBranch != expectedBranch {
+					t.Fatalf("call Git Branch expected to be (%v) but was (%v)", expectedBranch, captureBranch)
+				}
+				if captureDir, expectedDir := pointer.StringPtrDerefOr(captureFn.Git.ContextDir, ""), pointer.StringPtrDerefOr(tt.expectCallContextDir, ""); captureDir != expectedDir {
+					t.Fatalf("call Git Dir expected to be (%v) but was (%v)", expectedDir, captureDir)
+				}
+			}
+		})
+	}
+}

--- a/cmd/deploy_test.go
+++ b/cmd/deploy_test.go
@@ -96,7 +96,7 @@ git:
 			funcFile: `name: test-func
 runtime: go
 created: 2009-11-10 23:00:00`,
-			errString: "remote git arguments require the --build=remote flag",
+			errString: "remote git arguments require the --build=git flag",
 		},
 	}
 	for _, tt := range tests {

--- a/cmd/deploy_test.go
+++ b/cmd/deploy_test.go
@@ -106,7 +106,7 @@ git:
 				t.Fatal(err)
 			}
 
-			ctx, _ := context.WithCancel(context.TODO())
+			ctx := context.TODO()
 
 			_, err := cmd.ExecuteContextC(ctx)
 			if err != nil {

--- a/go.mod
+++ b/go.mod
@@ -37,6 +37,7 @@ require (
 	k8s.io/api v0.22.5
 	k8s.io/apimachinery v0.22.5
 	k8s.io/client-go v0.22.5
+	k8s.io/utils v0.0.0-20210819203725-bdf08cb9a70a
 	knative.dev/client v0.27.0
 	knative.dev/eventing v0.27.2
 	knative.dev/hack v0.0.0-20220216040439-0456e8bf6547

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1257,6 +1257,7 @@ k8s.io/kube-openapi/pkg/common
 k8s.io/kube-openapi/pkg/util/proto
 k8s.io/kube-openapi/pkg/validation/spec
 # k8s.io/utils v0.0.0-20210819203725-bdf08cb9a70a
+## explicit
 k8s.io/utils/buffer
 k8s.io/utils/integer
 k8s.io/utils/pointer


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

# Changes

<!-- 
Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! 

- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->
- New flags added as counter part to `func.yaml` git configuration
- Git flags are no longer saved to `func.yaml`

<!--
In addition, categorize the changes you're making using the "/kind" Prow command, example:

/kind <kind>

Supported kinds are: api-change, bug, cleanup, deprecation, removal, documentation, enhancement, performance

-->
/kind <kind>

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #765

<!-- Please include the 'why' behind your changes if no issue exists -->

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->
```release-note
`--git-url` `--git-branch` and `--git-dir` flags added for remote builds
```

**Docs**

<!--
:book: If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [knative/docs]: <issue or pr link>
- [Feature Track]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
