### PR TITLE
src: promote verbosity to constructor arg

### DIFF
--- a/buildpacks/builder.go
+++ b/buildpacks/builder.go
@@ -24,12 +24,12 @@ import (
 //Builder holds the configuration that will be passed to
 //Buildpack builder
 type Builder struct {
-	Verbose bool
+	verbose bool
 }
 
 //NewBuilder builds the new Builder configuration
-func NewBuilder() *Builder {
-	return &Builder{}
+func NewBuilder(verbose bool) *Builder {
+	return &Builder{verbose: verbose}
 }
 
 var v330 = semver.MustParse("v3.3.0")
@@ -57,7 +57,7 @@ func (builder *Builder) Build(ctx context.Context, f fn.Function) (err error) {
 
 	// log output is either STDOUt or kept in a buffer to be printed on error.
 	var logWriter io.Writer
-	if builder.Verbose {
+	if builder.verbose {
 		// pass stdout as non-closeable writer
 		// otherwise pack client would close it which is bad
 		logWriter = stdoutWrapper{os.Stdout}
@@ -130,7 +130,7 @@ func (builder *Builder) Build(ctx context.Context, f fn.Function) (err error) {
 		if ctx.Err() != nil {
 			// received SIGINT
 			return
-		} else if !builder.Verbose {
+		} else if !builder.verbose {
 			// If the builder was not showing logs, embed the full logs in the error.
 			err = fmt.Errorf("%v\noutput: %s\n", err, logWriter.(*bytes.Buffer).String())
 		}

--- a/client_int_test.go
+++ b/client_int_test.go
@@ -59,7 +59,7 @@ func TestList(t *testing.T) {
 	verbose := true
 
 	// Assemble
-	lister := knative.NewLister(DefaultNamespace)
+	lister := knative.NewLister(DefaultNamespace, verbose)
 
 	client := fn.New(
 		fn.WithLister(lister),
@@ -203,20 +203,11 @@ func TestRemoteRepositories(t *testing.T) {
 // newClient creates an instance of the func client whose concrete impls
 // match those created by the kn func plugin CLI.
 func newClient(verbose bool) *fn.Client {
-	builder := buildpacks.NewBuilder()
-	builder.Verbose = verbose
-
-	pusher := docker.NewPusher()
-	pusher.Verbose = verbose
-
-	deployer := knative.NewDeployer(DefaultNamespace)
-	deployer.Verbose = verbose
-
-	remover := knative.NewRemover(DefaultNamespace)
-	remover.Verbose = verbose
-
-	lister := knative.NewLister(DefaultNamespace)
-	lister.Verbose = verbose
+	builder := buildpacks.NewBuilder(verbose)
+	pusher := docker.NewPusher(verbose)
+	deployer := knative.NewDeployer(DefaultNamespace, verbose)
+	remover := knative.NewRemover(DefaultNamespace, verbose)
+	lister := knative.NewLister(DefaultNamespace, verbose)
 
 	return fn.New(
 		fn.WithRegistry(DefaultRegistry),

--- a/cmd/client.go
+++ b/cmd/client.go
@@ -52,11 +52,10 @@ func NewDefaultClientFactory() (newClient ClientFactory, cleanUp func() error) {
 	}
 
 	newClient = func(clientOptions ClientOptions) *fn.Client {
-		builder := buildpacks.NewBuilder()
-		builder.Verbose = clientOptions.Verbose
+		verbose := clientOptions.Verbose
+		builder := buildpacks.NewBuilder(verbose)
 
-		progressListener := progress.New()
-		progressListener.Verbose = clientOptions.Verbose
+		progressListener := progress.New(verbose)
 
 		credentialsProvider := creds.NewCredentialsProvider(
 			creds.WithPromptForCredentials(newPromptForCredentials()),
@@ -64,37 +63,30 @@ func NewDefaultClientFactory() (newClient ClientFactory, cleanUp func() error) {
 			creds.WithTransport(transport),
 			creds.WithAdditionalCredentialLoaders(additionalCredLoaders...))
 
-		pusher := docker.NewPusher(
+		pusher := docker.NewPusher(verbose,
 			docker.WithCredentialsProvider(credentialsProvider),
 			docker.WithProgressListener(progressListener),
 			docker.WithTransport(transport))
-		pusher.Verbose = clientOptions.Verbose
 
-		deployer := knative.NewDeployer(clientOptions.Namespace)
-		deployer.Verbose = clientOptions.Verbose
+		deployer := knative.NewDeployer(clientOptions.Namespace, verbose)
 
-		pipelinesProvider := tekton.NewPipelinesProvider(
+		pipelinesProvider := tekton.NewPipelinesProvider(verbose,
 			tekton.WithNamespace(clientOptions.Namespace),
 			tekton.WithProgressListener(progressListener),
 			tekton.WithCredentialsProvider(credentialsProvider))
-		pipelinesProvider.Verbose = clientOptions.Verbose
 
-		remover := knative.NewRemover(clientOptions.Namespace)
-		remover.Verbose = clientOptions.Verbose
+		remover := knative.NewRemover(clientOptions.Namespace, verbose)
 
-		describer := knative.NewDescriber(clientOptions.Namespace)
-		describer.Verbose = clientOptions.Verbose
+		describer := knative.NewDescriber(clientOptions.Namespace, verbose)
 
-		lister := knative.NewLister(clientOptions.Namespace)
-		lister.Verbose = clientOptions.Verbose
+		lister := knative.NewLister(clientOptions.Namespace, verbose)
 
-		runner := docker.NewRunner()
-		runner.Verbose = clientOptions.Verbose
+		runner := docker.NewRunner(verbose)
 
 		opts := []fn.Option{
 			fn.WithRepository(clientOptions.Repository), // URI of repository override
 			fn.WithRegistry(clientOptions.Registry),
-			fn.WithVerbose(clientOptions.Verbose),
+			fn.WithVerbose(verbose),
 			fn.WithTransport(transport),
 			fn.WithProgressListener(progressListener),
 			fn.WithBuilder(builder),

--- a/cmd/completion_util.go
+++ b/cmd/completion_util.go
@@ -15,7 +15,7 @@ import (
 )
 
 func CompleteFunctionList(cmd *cobra.Command, args []string, toComplete string) (strings []string, directive cobra.ShellCompDirective) {
-	lister := knative.NewLister("")
+	lister := knative.NewLister("", false)
 
 	list, err := lister.List(cmd.Context())
 	if err != nil {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -366,7 +366,7 @@ func (v Version) String() string {
 	// value v0.0.0 as the default indicating there is no version information
 	// available.
 	if strings.HasPrefix(v.Vers, "v") {
-		// TODO: this is the naieve approach, perhaps consider actually parse it
+		// TODO: this is the naive approach, perhaps consider actually parse it
 		// using the semver lib
 		return v.Vers
 	}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -62,7 +62,7 @@ EXAMPLES
 	// Environment Variables
 	// Evaluated first after static defaults, set all flags to be associated with
 	// a version prefixed by "FUNC_"
-	viper.AutomaticEnv()       // read in environment variables that match
+	viper.AutomaticEnv()       // read in environment variables for FUNC_<flag>
 	viper.SetEnvPrefix("func") // ensure thay all have the prefix
 
 	// Flags

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -17,14 +17,11 @@ import (
 
 func newRunClient(cfg runConfig) *fn.Client {
 	bc := newBuildConfig()
-	runner := docker.NewRunner()
-	runner.Verbose = cfg.Verbose
+	runner := docker.NewRunner(cfg.Verbose)
 
 	// builder fields
-	builder := buildpacks.NewBuilder()
-	listener := progress.New()
-	builder.Verbose = cfg.Verbose
-	listener.Verbose = cfg.Verbose
+	builder := buildpacks.NewBuilder(cfg.Verbose)
+	listener := progress.New(cfg.Verbose)
 	return fn.New(
 		fn.WithBuilder(builder),
 		fn.WithProgressListener(listener),

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -41,7 +41,6 @@ DESCRIPTION
 	cmd.Run = func(cmd *cobra.Command, args []string) {
 		runVersion(cmd, args, version)
 	}
-	cmd.SetHelpFunc(defaultTemplatedHelp)
 
 	return cmd
 }

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -2,7 +2,6 @@ package cmd
 
 import (
 	"fmt"
-	"text/template"
 
 	"github.com/ory/viper"
 	"github.com/spf13/cobra"
@@ -35,7 +34,7 @@ DESCRIPTION
 	}
 
 	// Help Action
-	cmd.SetHelpFunc(runVersionHelp)
+	cmd.SetHelpFunc(defaultTemplatedHelp)
 
 	// Run Action
 	cmd.Run = func(cmd *cobra.Command, args []string) {
@@ -49,23 +48,4 @@ DESCRIPTION
 func runVersion(cmd *cobra.Command, args []string, version Version) {
 	version.Verbose = viper.GetBool("verbose")
 	fmt.Fprintf(cmd.OutOrStdout(), "%v\n", version)
-}
-
-// Help
-func runVersionHelp(cmd *cobra.Command, args []string) {
-	var (
-		body = cmd.Long + "\n\n" + cmd.UsageString()
-		t    = template.New("version")
-		tpl  = template.Must(t.Parse(body))
-	)
-
-	var data = struct {
-		Name string
-	}{
-		Name: cmd.Root().Name(),
-	}
-
-	if err := tpl.Execute(cmd.OutOrStdout(), data); err != nil {
-		fmt.Fprintf(cmd.ErrOrStderr(), "unable to display help text: %v", err)
-	}
 }

--- a/docker/pusher.go
+++ b/docker/pusher.go
@@ -47,8 +47,7 @@ type PusherDockerClientFactory func() (PusherDockerClient, error)
 
 // Pusher of images from local to remote registry.
 type Pusher struct {
-	// Verbose logging.
-	Verbose             bool
+	verbose             bool // verbose logging.
 	credentialsProvider CredentialsProvider
 	progressListener    fn.ProgressListener
 	transport           http.RoundTripper
@@ -84,9 +83,8 @@ func EmptyCredentialsProvider(ctx context.Context, registry string) (Credentials
 }
 
 // NewPusher creates an instance of a docker-based image pusher.
-func NewPusher(opts ...Opt) *Pusher {
+func NewPusher(verbose bool, opts ...Opt) *Pusher {
 	result := &Pusher{
-		Verbose:             false,
 		credentialsProvider: EmptyCredentialsProvider,
 		progressListener:    &fn.NoopProgressListener{},
 		transport:           http.DefaultTransport,
@@ -94,6 +92,7 @@ func NewPusher(opts ...Opt) *Pusher {
 			c, _, err := NewClient(client.DefaultDockerHost)
 			return c, err
 		},
+		verbose: verbose,
 	}
 	for _, opt := range opts {
 		opt(result)
@@ -116,7 +115,7 @@ func (n *Pusher) Push(ctx context.Context, f fn.Function) (digest string, err er
 
 	var output io.Writer
 
-	if n.Verbose {
+	if n.verbose {
 		output = os.Stderr
 	} else {
 		output = io.Discard

--- a/docker/pusher_test.go
+++ b/docker/pusher_test.go
@@ -105,7 +105,7 @@ func TestDaemonPush(t *testing.T) {
 	dockerClientFactory := func() (docker.PusherDockerClient, error) {
 		return dockerClient, nil
 	}
-	pusher := docker.NewPusher(
+	pusher := docker.NewPusher(false,
 		docker.WithCredentialsProvider(testCredProvider),
 		docker.WithPusherDockerClientFactory(dockerClientFactory))
 
@@ -182,7 +182,7 @@ func TestNonDaemonPush(t *testing.T) {
 		return dockerClient, nil
 	}
 
-	pusher := docker.NewPusher(
+	pusher := docker.NewPusher(false,
 		docker.WithTransport(transport),
 		docker.WithCredentialsProvider(testCredProvider),
 		docker.WithPusherDockerClientFactory(dockerClientFactory))

--- a/docker/runner.go
+++ b/docker/runner.go
@@ -36,13 +36,12 @@ const (
 
 // Runner starts and stops Functions as local contaieners.
 type Runner struct {
-	// Verbose logging
-	Verbose bool
+	verbose bool // Verbose logging
 }
 
 // NewRunner creates an instance of a docker-backed runner.
-func NewRunner() *Runner {
-	return &Runner{}
+func NewRunner(verbose bool) *Runner {
+	return &Runner{verbose: verbose}
 }
 
 // Run the Function.
@@ -69,7 +68,7 @@ func (n *Runner) Run(ctx context.Context, f fn.Function) (job *fn.Job, err error
 	if c, _, err = NewClient(client.DefaultDockerHost); err != nil {
 		return job, errors.Wrap(err, "failed to create Docker API client")
 	}
-	if id, err = newContainer(ctx, c, f, port, n.Verbose); err != nil {
+	if id, err = newContainer(ctx, c, f, port, n.verbose); err != nil {
 		return job, errors.Wrap(err, "runner unable to create container")
 	}
 	if conn, err = copyStdio(ctx, c, id, copyErrCh); err != nil {

--- a/docker/runner_test.go
+++ b/docker/runner_test.go
@@ -35,8 +35,7 @@ func TestDockerRun(t *testing.T) {
 
 	// NOTE: test requires that the image be built already.
 
-	runner := docker.NewRunner()
-	runner.Verbose = true
+	runner := docker.NewRunner(true)
 	if _, err = runner.Run(context.Background(), f); err != nil {
 		t.Fatal(err)
 	}
@@ -48,7 +47,7 @@ func TestDockerRun(t *testing.T) {
 }
 
 func TestDockerRunImagelessError(t *testing.T) {
-	runner := docker.NewRunner()
+	runner := docker.NewRunner(true)
 	f := fn.NewFunctionWith(fn.Function{})
 
 	_, err := runner.Run(context.Background(), f)

--- a/knative/deployer.go
+++ b/knative/deployer.go
@@ -32,13 +32,14 @@ type Deployer struct {
 	// Namespace with which to override that set on the default configuration (such as the ~/.kube/config).
 	// If left blank, deployment will commence to the configured namespace.
 	Namespace string
-	// Verbose logging enablement flag.
-	Verbose bool
+	// verbose logging enablement flag.
+	verbose bool
 }
 
-func NewDeployer(namespaceOverride string) *Deployer {
+func NewDeployer(namespaceOverride string, verbose bool) *Deployer {
 	return &Deployer{
 		Namespace: namespaceOverride,
+		verbose:   verbose,
 	}
 }
 
@@ -110,7 +111,7 @@ func (d *Deployer) Deploy(ctx context.Context, f fn.Function) (result fn.Deploym
 				return fn.DeploymentResult{}, err
 			}
 
-			if d.Verbose {
+			if d.verbose {
 				fmt.Println("Waiting for Knative Service to become ready")
 			}
 			chprivate := make(chan bool)
@@ -159,7 +160,7 @@ func (d *Deployer) Deploy(ctx context.Context, f fn.Function) (result fn.Deploym
 				return fn.DeploymentResult{}, err
 			}
 
-			if d.Verbose {
+			if d.verbose {
 				fmt.Println("Function deployed at URL: " + route.Status.URL.String())
 			}
 			return fn.DeploymentResult{

--- a/knative/describer.go
+++ b/knative/describer.go
@@ -12,13 +12,14 @@ import (
 )
 
 type Describer struct {
-	Verbose   bool
 	namespace string
+	verbose   bool
 }
 
-func NewDescriber(namespaceOverride string) *Describer {
+func NewDescriber(namespaceOverride string, verbose bool) *Describer {
 	return &Describer{
 		namespace: namespaceOverride,
+		verbose:   verbose,
 	}
 }
 

--- a/knative/lister.go
+++ b/knative/lister.go
@@ -13,13 +13,14 @@ import (
 )
 
 type Lister struct {
-	Verbose   bool
 	Namespace string
+	verbose   bool
 }
 
-func NewLister(namespaceOverride string) *Lister {
+func NewLister(namespaceOverride string, verbose bool) *Lister {
 	return &Lister{
 		Namespace: namespaceOverride,
+		verbose:   verbose,
 	}
 }
 

--- a/knative/remover.go
+++ b/knative/remover.go
@@ -10,15 +10,16 @@ import (
 
 const RemoveTimeout = 120 * time.Second
 
-func NewRemover(namespaceOverride string) *Remover {
+func NewRemover(namespaceOverride string, verbose bool) *Remover {
 	return &Remover{
 		Namespace: namespaceOverride,
+		verbose:   verbose,
 	}
 }
 
 type Remover struct {
 	Namespace string
-	Verbose   bool
+	verbose   bool
 }
 
 func (remover *Remover) Remove(ctx context.Context, name string) (err error) {

--- a/openshift/openshift.go
+++ b/openshift/openshift.go
@@ -148,14 +148,24 @@ func GetDockerCredentialLoaders() []creds.CredentialsCallback {
 
 }
 
+// FIXME(lkingland):
+// Using this global variable meaans any processing importing this package
+// will be "locked" to the value of the cluster to which it is attached on the
+// first call.  This breaks the ability to have multiple instances of the Client
+// which change their target cluster during execution.
 var isOpenShift bool
 var checkOpenShiftOnce sync.Once
 
 func IsOpenShift() bool {
 	checkOpenShiftOnce.Do(func() {
-		isOpenShift = false
+		isOpenShift = false // FIXME(lkingland):  False is the zero value.
 		client, err := k8s.NewKubernetesClientset()
 		if err != nil {
+			// FIXME(lkingland): This should perhaps print the err to stderr, but I
+			// suspect it would be better to bubble this error.  The caller probably
+			// would like to know the system was unable to determine if the target
+			// cluster is OpenShift, since a fair bit of logic relies on it.
+			isOpenShift = false
 			return
 		}
 		_, err = client.CoreV1().Services("openshift-image-registry").Get(context.TODO(), "image-registry", metav1.GetOptions{})
@@ -163,6 +173,15 @@ func IsOpenShift() bool {
 			isOpenShift = true
 			return
 		}
+		// FIXME(lkingland): This logic seems to obscure legitimate errors, treating
+		// them as equivalent to IsOpenShift==true.
+		// For example when no cluster is available, this fails with a connection
+		// refused error, leading to the system state of presuming we are in
+		// OpenShift mode.
+		// This may be improved by adopting a different detection mechanism, or at
+		// least.
+		// See [associated discussion](https://github.com/knative-sandbox/kn-plugin-func/pull/825#discussion_r811520395)
+		// See [appropos issue](https://github.com/knative-sandbox/kn-plugin-func/issues/867)
 	})
 	return isOpenShift
 }

--- a/pipelines/tekton/pipeplines_provider.go
+++ b/pipelines/tekton/pipeplines_provider.go
@@ -30,7 +30,7 @@ type PipelinesProvider struct {
 	// namespace with which to override that set on the default configuration (such as the ~/.kube/config).
 	// If left blank, pipeline creation/run will commence to the configured namespace.
 	namespace           string
-	Verbose             bool
+	verbose             bool
 	progressListener    fn.ProgressListener
 	credentialsProvider docker.CredentialsProvider
 }
@@ -53,8 +53,8 @@ func WithCredentialsProvider(credentialsProvider docker.CredentialsProvider) Opt
 	}
 }
 
-func NewPipelinesProvider(opts ...Opt) *PipelinesProvider {
-	pp := &PipelinesProvider{}
+func NewPipelinesProvider(verbose bool, opts ...Opt) *PipelinesProvider {
+	pp := &PipelinesProvider{verbose: verbose}
 
 	for _, opt := range opts {
 		opt(pp)

--- a/progress/progress.go
+++ b/progress/progress.go
@@ -43,7 +43,7 @@ type Bar struct {
 
 	// verbose mode disables progress spinner and line overwrites, instead
 	// printing single, full line updates.
-	Verbose bool
+	verbose bool
 
 	// print verbose-style updates even when not attached to an interactive terminal.
 	printWhileHeadless bool
@@ -78,9 +78,10 @@ func WithPrintStepCounter(s bool) Option {
 	}
 }
 
-func New(options ...Option) *Bar {
+func New(verbose bool, options ...Option) *Bar {
 	b := &Bar{
-		out: os.Stdout,
+		out:     os.Stdout,
+		verbose: verbose,
 	}
 	for _, o := range options {
 		o(b)
@@ -110,7 +111,7 @@ func (b *Bar) Increment(text string) {
 	}
 
 	// If we're in verbose mode, do a simple write
-	if b.Verbose {
+	if b.verbose {
 		b.write()
 		return
 	}
@@ -144,7 +145,7 @@ func (b *Bar) Complete(text string) {
 	}
 
 	// If we're interactive, but in verbose mode do a simple write
-	if b.Verbose {
+	if b.verbose {
 		b.write()
 		return
 	}
@@ -213,7 +214,7 @@ func (b *Bar) String() string {
 
 // Write a spinner at the beginning of the previous line.
 func (b *Bar) spin(ch <-chan time.Time) {
-	if b.Verbose {
+	if b.verbose {
 		return
 	}
 	// Various options for spinners.


### PR DESCRIPTION
# Changes

**tl;dr** Probably best to use _either_ constructor args _or_ struct member initialization and not mix.  We have chosen constructors for package public API and struct members for package internal implementations.  This enforces that choice with regards to the oft-ignored verbosity flag.

- :broom: Moves verbosity flag to constructor arg

This rectifies a long-standing inconsistency where, early in the system's evolution all subsystems were initialized as simple structs.  When we moved to using proper constructors, the Verbosity flag was left as a struct member.  This is a bit confusing and awkward because it mixes constructor-based configuration with the direct setting of struct members.  The former is often best for external package APIs, the latter is often best for internal.  This situation straddles the line, because these packages are used by their parent package, so either way could be a defensible position.

Explicitly requiring the verbosity to be provided in the constructor is not awe-inspiring elegance, but I suppose mixing constructor-based initialization with struct members much less so.  This is evidenced by how much `main`'s default Client constructor is simplified by requiring this flag in the constructor.

/kind cleanup
