### PR TITLE
fix: use full root name for cmd help prefixes

### DIFF
--- a/cmd/create.go
+++ b/cmd/create.go
@@ -172,7 +172,7 @@ func runCreateHelp(cmd *cobra.Command, args []string, newClient ClientFactory) {
 		Name    string
 	}{
 		Options: options,
-		Name:    cmd.Root().Name(),
+		Name:    cmd.Root().Use,
 	}
 	if err := tpl.Execute(cmd.OutOrStdout(), data); err != nil {
 		fmt.Fprintf(cmd.ErrOrStderr(), "unable to display help text: %v", err)

--- a/cmd/invoke.go
+++ b/cmd/invoke.go
@@ -183,7 +183,7 @@ func runInvokeHelp(cmd *cobra.Command, args []string, newClient ClientFactory) {
 	var data = struct {
 		Name string
 	}{
-		Name: cmd.Root().Name(),
+		Name: cmd.Root().Use,
 	}
 
 	if err := tpl.Execute(cmd.OutOrStdout(), data); err != nil {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -43,6 +43,8 @@ func NewRootCmd(config RootCommandConfig) (*cobra.Command, error) {
 	var err error
 
 	root := &cobra.Command{
+		// Use must be set to exactly config.Name, as this field is overloaded to
+		// be used in subcommand help text as the command with possible prefix:
 		Use:           config.Name,
 		Short:         "Serverless Functions",
 		SilenceErrors: true, // we explicitly handle errors in Execute()


### PR DESCRIPTION
# Changes

Small change to use `cmd.Root().Use` for subcommand help text because `.Name()` is truncated, leading to incorrect values when run in plugin mode (see #872)

- :bug: fix help text subcommand prefixes when a plugin

/kind bug

Fixes #872 