### PR TITLE
feat: command help text template preprocessing

### DIFF
--- a/cmd/build.go
+++ b/cmd/build.go
@@ -35,16 +35,16 @@ and the image name is stored in the configuration file.
 # Build from the local directory, using the given registry as target.
 # The full image name will be determined automatically based on the
 # project directory name
-kn func build --registry quay.io/myuser
+{{.Name}} build --registry quay.io/myuser
 
 # Build from the local directory, specifying the full image name
-kn func build --image quay.io/myuser/myfunc
+{{.Name}} build --image quay.io/myuser/myfunc
 
 # Re-build, picking up a previously supplied image name from a local func.yml
-kn func build
+{{.Name}} build
 
 # Build with a custom buildpack builder
-kn func build --builder cnbs/sample-builder:bionic
+{{.Name}} build --builder cnbs/sample-builder:bionic
 `,
 		SuggestFor: []string{"biuld", "buidl", "built"},
 		PreRunE:    bindEnv("image", "path", "builder", "registry", "confirm", "push"),
@@ -60,6 +60,8 @@ kn func build --builder cnbs/sample-builder:bionic
 	if err := cmd.RegisterFlagCompletionFunc("builder", CompleteBuilderList); err != nil {
 		fmt.Println("internal: error while calling RegisterFlagCompletionFunc: ", err)
 	}
+
+	cmd.SetHelpFunc(defaultTemplatedHelp)
 
 	cmd.RunE = func(cmd *cobra.Command, args []string) error {
 		return runBuild(cmd, args, newClient)

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -57,6 +57,7 @@ or from the directory specified with --path.
 		PreRunE:    bindEnv("path"),
 		RunE:       runConfigCmd,
 	}
+	cmd.SetHelpFunc(defaultTemplatedHelp)
 
 	setPathFlag(cmd)
 

--- a/cmd/config_envs.go
+++ b/cmd/config_envs.go
@@ -51,7 +51,7 @@ the current directory or from the directory specified with --path.
 }
 
 func NewConfigEnvsAddCmd() *cobra.Command {
-	return &cobra.Command{
+	cmd := &cobra.Command{
 		Use:   "add",
 		Short: "Add environment variable to the function configuration",
 		Long: `Add environment variable to the function configuration
@@ -73,7 +73,8 @@ from an environment variable on the local machine or from Secrets and ConfigMaps
 			return runAddEnvsPrompt(cmd.Context(), function)
 		},
 	}
-
+	cmd.SetHelpFunc(defaultTemplatedHelp)
+	return cmd
 }
 
 func NewConfigEnvsRemoveCmd() *cobra.Command {

--- a/cmd/config_labels.go
+++ b/cmd/config_labels.go
@@ -35,6 +35,7 @@ the current directory or from the directory specified with --path.
 			return
 		},
 	}
+	configLabelsCmd.SetHelpFunc(defaultTemplatedHelp)
 
 	var configLabelsAddCmd = &cobra.Command{
 		Use:   "add",
@@ -58,6 +59,7 @@ the local machine.
 			return runAddLabelsPrompt(cmd.Context(), function, loaderSaver)
 		},
 	}
+	configLabelsAddCmd.SetHelpFunc(defaultTemplatedHelp)
 
 	var configLabelsRemoveCmd = &cobra.Command{
 		Use:   "remove",
@@ -78,6 +80,7 @@ directory or from the directory specified with --path.
 			return runRemoveLabelsPrompt(function, loaderSaver)
 		},
 	}
+	configLabelsRemoveCmd.SetHelpFunc(defaultTemplatedHelp)
 
 	setPathFlag(configLabelsCmd)
 	setPathFlag(configLabelsAddCmd)

--- a/cmd/config_volumes.go
+++ b/cmd/config_volumes.go
@@ -35,6 +35,7 @@ the current directory or from the directory specified with --path.
 			return
 		},
 	}
+	cmd.SetHelpFunc(defaultTemplatedHelp)
 
 	configVolumesAddCmd := NewConfigVolumesAddCmd()
 	configVolumesRemoveCmd := NewConfigVolumesRemoveCmd()
@@ -50,7 +51,7 @@ the current directory or from the directory specified with --path.
 }
 
 func NewConfigVolumesAddCmd() *cobra.Command {
-	return &cobra.Command{
+	cmd := &cobra.Command{
 		Use:   "add",
 		Short: "Add volume to the function configuration",
 		Long: `Add volume to the function configuration
@@ -69,11 +70,12 @@ in the current directory or from the directory specified with --path.
 			return runAddVolumesPrompt(cmd.Context(), function)
 		},
 	}
-
+	cmd.SetHelpFunc(defaultTemplatedHelp)
+	return cmd
 }
 
 func NewConfigVolumesRemoveCmd() *cobra.Command {
-	return &cobra.Command{
+	cmd := &cobra.Command{
 		Use:   "remove",
 		Short: "Remove volume from the function configuration",
 		Long: `Remove volume from the function configuration
@@ -92,7 +94,8 @@ in the current directory or from the directory specified with --path.
 			return runRemoveVolumesPrompt(function)
 		},
 	}
-
+	cmd.SetHelpFunc(defaultTemplatedHelp)
+	return cmd
 }
 
 func listVolumes(f fn.Function) {

--- a/cmd/delete.go
+++ b/cmd/delete.go
@@ -25,10 +25,10 @@ No local files are deleted.
 `,
 		Example: `
 # Undeploy the function defined in the local directory
-kn func delete
+{{.Name}} delete
 
 # Undeploy the function 'myfunc' in namespace 'apps'
-kn func delete -n apps myfunc
+{{.Name}} delete -n apps myfunc
 `,
 		SuggestFor:        []string{"remove", "rm", "del"},
 		ValidArgsFunction: CompleteFunctionList,
@@ -39,6 +39,8 @@ kn func delete -n apps myfunc
 	cmd.Flags().StringP("all", "a", "true", "Delete all resources created for a function, eg. Pipelines, Secrets, etc. (Env: $FUNC_ALL) (allowed values: \"true\", \"false\")")
 	setNamespaceFlag(cmd)
 	setPathFlag(cmd)
+
+	cmd.SetHelpFunc(defaultTemplatedHelp)
 
 	cmd.RunE = func(cmd *cobra.Command, args []string) error {
 		return runDelete(cmd, args, newClient)

--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -44,11 +44,11 @@ that is pushed to an image registry, and finally the function's Knative service 
 # Build and deploy the function from the current directory's project. The image will be
 # pushed to "quay.io/myuser/<function name>" and deployed as Knative service with the 
 # same name as the function to the currently connected cluster.
-kn func deploy --registry quay.io/myuser
+{{.Name}} deploy --registry quay.io/myuser
 
 # Same as above but using a full image name, that will create a Knative service "myfunc" in 
 # the namespace "myns"
-kn func deploy --image quay.io/myuser/myfunc -n myns
+{{.Name}} deploy --image quay.io/myuser/myfunc -n myns
 `,
 		SuggestFor: []string{"delpoy", "deplyo"},
 		PreRunE:    bindEnv("image", "namespace", "path", "registry", "confirm", "build", "push", "git-url", "git-branch", "git-dir"),
@@ -71,6 +71,8 @@ kn func deploy --image quay.io/myuser/myfunc -n myns
 	if err := cmd.RegisterFlagCompletionFunc("build", CompleteDeployBuildType); err != nil {
 		fmt.Println("internal: error while calling RegisterFlagCompletionFunc: ", err)
 	}
+
+	cmd.SetHelpFunc(defaultTemplatedHelp)
 
 	cmd.RunE = func(cmd *cobra.Command, args []string) error {
 		return runDeploy(cmd, args, newClient)

--- a/cmd/info.go
+++ b/cmd/info.go
@@ -25,10 +25,10 @@ the current directory or from the directory specified with --path.
 `,
 		Example: `
 # Show the details of a function as declared in the local func.yaml
-kn func info
+{{.Name}} info
 
 # Show the details of the function in the myotherfunc directory with yaml output
-kn func info --output yaml --path myotherfunc
+{{.Name}} info --output yaml --path myotherfunc
 `,
 		SuggestFor:        []string{"ifno", "describe", "fino", "get"},
 		ValidArgsFunction: CompleteFunctionList,
@@ -42,6 +42,8 @@ kn func info --output yaml --path myotherfunc
 	if err := cmd.RegisterFlagCompletionFunc("output", CompleteOutputFormatList); err != nil {
 		fmt.Println("internal: error while calling RegisterFlagCompletionFunc: ", err)
 	}
+
+	cmd.SetHelpFunc(defaultTemplatedHelp)
 
 	cmd.RunE = func(cmd *cobra.Command, args []string) error {
 		return runInfo(cmd, args, newClient)

--- a/cmd/invoke.go
+++ b/cmd/invoke.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
-	"text/template"
 
 	"github.com/AlecAivazis/survey/v2"
 	"github.com/google/uuid"
@@ -116,10 +115,7 @@ EXAMPLES
 	cmd.Flags().BoolP("confirm", "c", false, "Prompt to confirm all options interactively. (Env: $FUNC_CONFIRM)")
 	setNamespaceFlag(cmd)
 
-	// Help Action
-	cmd.SetHelpFunc(func(cmd *cobra.Command, args []string) {
-		runInvokeHelp(cmd, args, newClient)
-	})
+	cmd.SetHelpFunc(defaultTemplatedHelp)
 
 	// Run Action
 	cmd.RunE = func(cmd *cobra.Command, args []string) error {
@@ -171,24 +167,6 @@ func runInvoke(cmd *cobra.Command, args []string, newClient ClientFactory) (err 
 
 	fmt.Fprintf(cmd.OutOrStderr(), "Invoked %v\n", cfg.Target)
 	return
-}
-
-func runInvokeHelp(cmd *cobra.Command, args []string, newClient ClientFactory) {
-	var (
-		body = cmd.Long + "\n\n" + cmd.UsageString()
-		t    = template.New("invoke")
-		tpl  = template.Must(t.Parse(body))
-	)
-
-	var data = struct {
-		Name string
-	}{
-		Name: cmd.Root().Use,
-	}
-
-	if err := tpl.Execute(cmd.OutOrStdout(), data); err != nil {
-		fmt.Fprintf(cmd.ErrOrStderr(), "unable to display help text: %v", err)
-	}
 }
 
 type invokeConfig struct {

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -26,13 +26,13 @@ Lists all deployed functions in a given namespace.
 `,
 		Example: `
 # List all functions in the current namespace with human readable output
-kn func list
+{{.Name}} list
 
 # List all functions in the 'test' namespace with yaml output
-kn func list --namespace test --output yaml
+{{.Name}} list --namespace test --output yaml
 
 # List all functions in all namespaces with JSON output
-kn func list --all-namespaces --output json
+{{.Name}} list --all-namespaces --output json
 `,
 		SuggestFor: []string{"ls", "lsit"},
 		PreRunE:    bindEnv("namespace", "output"),
@@ -45,6 +45,8 @@ kn func list --all-namespaces --output json
 	if err := cmd.RegisterFlagCompletionFunc("output", CompleteOutputFormatList); err != nil {
 		fmt.Println("internal: error while calling RegisterFlagCompletionFunc: ", err)
 	}
+
+	cmd.SetHelpFunc(defaultTemplatedHelp)
 
 	cmd.RunE = func(cmd *cobra.Command, args []string) error {
 		return runList(cmd, args, newClient)

--- a/cmd/repository.go
+++ b/cmd/repository.go
@@ -41,14 +41,14 @@ func NewRepositoryCmd(clientFn repositoryClientFn) *cobra.Command {
 		Aliases: []string{"repo", "repositories"},
 		Long: `
 NAME
-	func-repository - Manage set of installed repositories.
+	{{.Name}} - Manage set of installed repositories.
 
 SYNOPSIS
-	func repo [-c|--confirm] [-v|--verbose]
-	func repo list [-r|--repositories] [-c|--confirm] [-v|--verbose]
-	func repo add <name> <url>[-r|--repositories] [-c|--confirm] [-v|--verbose]
-	func repo rename <old> <new> [-r|--repositories] [-c|--confirm] [-v|--verbose]
-	func repo remove <name> [-r|--repositories] [-c|--confirm] [-v|--verbose]
+	{{.Name}} repo [-c|--confirm] [-v|--verbose]
+	{{.Name}} repo list [-r|--repositories] [-c|--confirm] [-v|--verbose]
+	{{.Name}} repo add <name> <url>[-r|--repositories] [-c|--confirm] [-v|--verbose]
+	{{.Name}} repo rename <old> <new> [-r|--repositories] [-c|--confirm] [-v|--verbose]
+	{{.Name}} repo remove <name> [-r|--repositories] [-c|--confirm] [-v|--verbose]
 
 DESCRIPTION
 	Manage template repositories installed on disk at either the default location
@@ -73,7 +73,7 @@ DESCRIPTION
 	specifying a repository name prefix.
 	For example, to create a new Go function using the 'http' template from the
 	default repository.
-		$ func create -l go -t http
+		$ {{.Name}} create -l go -t http
 
 	The Repository Flag:
 	Installing repositories locally is optional.  To use a template from a remote
@@ -81,7 +81,7 @@ DESCRIPTION
 	This leaves the local disk untouched.  For example, To create a Function using
 	the Boson Project Hello-World template without installing the template
 	repository locally, use the --repository (-r) flag on create:
-		$ func create -l go \
+		$ {{.Name}} create -l go \
 			--template hello-world \
 			--repository https://github.com/boson-project/templates
 
@@ -89,19 +89,19 @@ COMMANDS
 
 	With no arguments, this help text is shown.  To manage repositories with
 	an interactive prompt, use the use the --confirm (-c) flag.
-	  $ func repository -c
+	  $ {{.Name}} repository -c
 
 	add
 	  Add a new repository to the installed set.
-	    $ func repository add <name> <URL>
+	    $ {{.Name}} repository add <name> <URL>
 
 	  For Example, to add the Boson Project repository:
-	    $ func repository add boson https://github.com/boson-project/templates
+	    $ {{.Name}} repository add boson https://github.com/boson-project/templates
 
 	  Once added, a Function can be created with templates from the new repository
 	  by prefixing the template name with the repository.  For example, to create
 	  a new Function using the Go Hello World template:
-	    $ func create -l go -t boson/hello-world
+	    $ {{.Name}} create -l go -t boson/hello-world
 
 	list
 	  List all available repositories, including the installed default
@@ -111,7 +111,7 @@ COMMANDS
 	rename
 	  Rename a previously installed repository from <old> to <new>. Only installed
 	  repositories can be renamed.
-	    $ func repository rename <name> <new name>
+	    $ {{.Name}} repository rename <name> <new name>
 
 	remove
 	  Remove a repository by name.  Removes the repository from local storage
@@ -119,40 +119,40 @@ COMMANDS
 	  deletion, but in regular mode this is done immediately, so please use
 	  caution, especially when using an altered repositories location
 	  (FUNC_REPOSITORIES environment variable or --repositories).
-	    $ func repository remove <name>
+	    $ {{.Name}} repository remove <name>
 
 EXAMPLES
 	o Run in confirmation mode (interactive prompts) using the --confirm flag
-	  $ func repository -c
+	  $ {{.Name}} repository -c
 
 	o Add a repository and create a new Function using a template from it:
-	  $ func repository add boson https://github.com/boson-project/templates
-	  $ func repository list
+	  $ {{.Name}} repository add boson https://github.com/boson-project/templates
+	  $ {{.Name}} repository list
 	  default
 	  boson
-	  $ func create -l go -t boson/hello-world
+	  $ {{.Name}} create -l go -t boson/hello-world
 	  ...
 
 	o List all repositories including the URL from which remotes were installed
-	  $ func repository list -v
+	  $ {{.Name}} repository list -v
 	  default
 	  boson	https://github.com/boson-project/templates
 
 	o Rename an installed repository
-	  $ func repository list
+	  $ {{.Name}} repository list
 	  default
 	  boson
-	  $ func repository rename boson boson-examples
-	  $ func repository list
+	  $ {{.Name}} repository rename boson boson-examples
+	  $ {{.Name}} repository list
 	  default
 	  boson-examples
 
 	o Remove an installed repository
-	  $ func repository list
+	  $ {{.Name}} repository list
 	  default
 	  boson-examples
-	  $ func repository remove boson-examples
-	  $ func repository list
+	  $ {{.Name}} repository remove boson-examples
+	  $ {{.Name}} repository list
 	  default
 `,
 		SuggestFor: []string{"repositories", "repos", "template", "templates", "pack", "packs"},
@@ -161,6 +161,8 @@ EXAMPLES
 
 	cmd.Flags().BoolP("confirm", "c", false, "Prompt to confirm all options interactively (Env: $FUNC_CONFIRM)")
 	cmd.Flags().StringP("repositories", "r", fn.RepositoriesPath(), "Path to language pack repositories (Env: $FUNC_REPOSITORIES)")
+
+	cmd.SetHelpFunc(defaultTemplatedHelp)
 
 	cmd.RunE = func(cmd *cobra.Command, args []string) error {
 		return runRepository(cmd, args, clientFn)

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -429,3 +429,19 @@ func surveySelectDefault(value string, options []string) string {
 	// which should fail proper validation
 	return ""
 }
+
+// defaultTemplatedHelp evaluates the given command's help text as a template
+// some commands define their own help command when additional values are
+// required beyond these basics.
+func defaultTemplatedHelp(cmd *cobra.Command, args []string) {
+	var (
+		body = cmd.Long + "\n\n" + cmd.UsageString()
+		t    = template.New("help")
+		tpl  = template.Must(t.Parse(body))
+	)
+	var data = struct{ Name string }{Name: cmd.Root().Use}
+
+	if err := tpl.Execute(cmd.OutOrStdout(), data); err != nil {
+		fmt.Fprintf(cmd.ErrOrStderr(), "unable to display help text: %v", err)
+	}
+}

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -47,10 +47,10 @@ specified by --path flag. The function must already have been built with the 'bu
 `,
 		Example: `
 # Build function's image first
-kn func build
+{{.Name}} build
 
 # Run it locally as a container
-kn func run
+{{.Name}} run
 `,
 		SuggestFor: []string{"rnu"},
 		PreRunE:    bindEnv("build", "path"),
@@ -62,6 +62,8 @@ kn func run
 			"To unset, specify the environment variable name followed by a \"-\" (e.g., NAME-).")
 	setPathFlag(cmd)
 	cmd.Flags().BoolP("build", "b", false, "Build the function only if the function has not been built before")
+
+	cmd.SetHelpFunc(defaultTemplatedHelp)
 
 	cmd.RunE = func(cmd *cobra.Command, args []string) error {
 		return runRun(cmd, args, clientFn)

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -23,6 +23,7 @@ Use the --verbose option to include the build date stamp and commit hash"
 		SuggestFor: []string{"vers", "verison"}, //nolint:misspell
 		Run:        runVersion,
 	}
+	cmd.SetHelpFunc(defaultTemplatedHelp)
 
 	return cmd
 }


### PR DESCRIPTION
# Changes

- :gift: all command help text template preprocessed

In preparation for a complete update of all command help text, this PR updates all commands to have their help text passed through a template preprocessor which, by default, provides the effective command name.

/kind enhancement

Fixes #216