### PR TITLE
Generate templates zip unconditionally

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -15,6 +15,8 @@ jobs:
       - uses: actions/setup-java@v1
         with:
           java-version: '11'
+      - name: Check embedded templates content
+        run: go test -run "^\QTestFileSystems\E$/^\Qembedded\E$"
       - name: Unit Test
         run:  make test
       - name: Template Unit Tests

--- a/Makefile
+++ b/Makefile
@@ -60,7 +60,9 @@ check: bin/golangci-lint ## Check code quality (lint)
 bin/golangci-lint:
 	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b ./bin v1.43.0
 
-zz_filesystem_generated.go: $(TEMPLATES)
+.PHONY: zz_filesystem_generated.go
+
+zz_filesystem_generated.go:
 	# Removing temporary template files
 	@rm -rf templates/node/cloudevents/node_modules
 	@rm -rf templates/node/http/node_modules

--- a/generate/templates/main.go
+++ b/generate/templates/main.go
@@ -13,6 +13,11 @@ import (
 	"path/filepath"
 )
 
+var hexs = []byte("0123456789abcdef")
+var space = []byte(" ")
+var newLine = []byte("\n")
+var tab = []byte("\t")
+
 // This program generates zz_filesystem_generated.go file containing byte array variable named templatesZip.
 // The variable contains zip of "./templates" directory.
 func main() {
@@ -80,10 +85,10 @@ func main() {
 		log.Fatal(err)
 	}
 
-	zipBytesReader := bytes.NewReader(zipBuff.Bytes())
 	buff := make([]byte, 32)
+	hexDigitWithComma := []byte("0x00,")
 	for {
-		n, err := zipBytesReader.Read(buff)
+		n, err := zipBuff.Read(buff)
 		if err != nil {
 			if errors.Is(err, io.EOF) {
 				break
@@ -92,32 +97,34 @@ func main() {
 			}
 		}
 
-		_, err = fmt.Fprintf(srcOut, "\t")
+		_, err = srcOut.Write(tab)
 		if err != nil {
 			log.Fatal(err)
 		}
 
 		for i, b := range buff[:n] {
-			_, err = fmt.Fprintf(srcOut, "0x%02x,", b)
+			hexDigitWithComma[2] = hexs[b>>4]
+			hexDigitWithComma[3] = hexs[b&0x0f]
+			_, err = srcOut.Write(hexDigitWithComma)
 			if err != nil {
 				log.Fatal(err)
 			}
 			if i < n-1 {
-				_, err = fmt.Fprintf(srcOut, " ")
+				_, err = srcOut.Write(space)
 				if err != nil {
 					log.Fatal(err)
 				}
 			}
 		}
 
-		_, err = fmt.Fprintf(srcOut, "\n")
+		_, err = srcOut.Write(newLine)
 		if err != nil {
 			log.Fatal(err)
 		}
 
 	}
 
-	_, err = fmt.Fprintf(srcOut, "}\n")
+	_, err = fmt.Fprint(srcOut, "}\n")
 	if err != nil {
 		log.Fatal(err)
 	}


### PR DESCRIPTION
Changes:
* Generate templates zip unconditionally (i.e. no `make` prerequisites).
  Rationale:
  * The way we create prerequisites (the `find` command) we cannot detect deleted files.
  * The generation is fast (around 500ms) so we can afford that.
* Some tiny performance tweaks.
* Test embedded templates content on push to `main`.
   The test has to run prior to `make test` because the `test` recipe enforces generation of the templates zip.
   It would prevent test from being run against git committed template.