### PR TITLE
src: differentiate repository from repositories

### DIFF
--- a/client.go
+++ b/client.go
@@ -246,7 +246,7 @@ func ConfigPath() (path string) {
 
 // RepositoriesPath accesses the currently effective repositories path,
 // which defaults to [ConfigPath]/repositories but can be set explicitly using
-// the WithRepositories option when creating the client..
+// the WithRepositoriesPath option when creating the client..
 // The path will be created if it does not already exist.
 func (c *Client) RepositoriesPath() (path string) {
 	path = c.repositories.Path()
@@ -256,7 +256,7 @@ func (c *Client) RepositoriesPath() (path string) {
 
 // RepositoriesPath is a convenience method for accessing the default path to
 // repositories that will be used by new instances of a Client unless options
-// such as WithRepositories are used to override.
+// such as WithRepositoriesPath are used to override.
 // The path will be created if it does not already exist.
 func RepositoriesPath() string {
 	return New().RepositoriesPath()
@@ -342,10 +342,10 @@ func WithDNSProvider(provider DNSProvider) Option {
 	}
 }
 
-// WithRepositories sets the location to use for extensible template
+// WithRepositoriesPath sets the location on disk to use for extensible template
 // repositories.  Extensible template repositories are additional templates
 // that exist on disk and are not built into the binary.
-func WithRepositories(path string) Option {
+func WithRepositoriesPath(path string) Option {
 	return func(c *Client) {
 		c.repositoriesPath = path
 	}

--- a/client_test.go
+++ b/client_test.go
@@ -212,9 +212,9 @@ func TestClient_New_HiddenFilesIgnored(t *testing.T) {
 // using a custom path to template repositories on disk. The custom repositories
 // location is not defined herein but expected to be provided because, for
 // example, a CLI may want to use XDG_CONFIG_HOME.  Assuming a repository path
-// $FUNC_REPOSITORIES, a Go template named 'json' which is provided in the
+// $FUNC_REPOSITORIES_PATH, a Go template named 'json' which is provided in the
 // repository 'boson', would be expected to be in the location:
-// $FUNC_REPOSITORIES/boson/go/json
+// $FUNC_REPOSITORIES_PATH/boson/go/json
 // See the CLI for full details, but a standard default location is
 // $HOME/.config/func/repositories/boson/go/json
 func TestClient_New_RepositoriesExtensible(t *testing.T) {
@@ -222,7 +222,7 @@ func TestClient_New_RepositoriesExtensible(t *testing.T) {
 	defer Using(t, root)()
 
 	client := fn.New(
-		fn.WithRepositories("testdata/repositories"),
+		fn.WithRepositoriesPath("testdata/repositories"),
 		fn.WithRegistry(TestRegistry))
 
 	// Create a Function specifying a template which only exists in the extensible set
@@ -262,7 +262,7 @@ func TestClient_New_RuntimeNotFoundCustom(t *testing.T) {
 
 	// Create a new client with path to the extensible templates
 	client := fn.New(
-		fn.WithRepositories("testdata/repositories"),
+		fn.WithRepositoriesPath("testdata/repositories"),
 		fn.WithRegistry(TestRegistry))
 
 	// Create a Function specifying a runtime, 'python' that does not exist
@@ -300,7 +300,7 @@ func TestClient_New_TemplateNotFoundCustom(t *testing.T) {
 
 	// Create a new client with path to extensible templates
 	client := fn.New(
-		fn.WithRepositories("testdata/repositories"),
+		fn.WithRepositoriesPath("testdata/repositories"),
 		fn.WithRegistry(TestRegistry))
 
 	// An invalid template, but a valid custom provider
@@ -1005,7 +1005,7 @@ func TestClient_Runtimes(t *testing.T) {
 	// TODO: test when a specific repo override is indicated
 	// (remote repo which takes precidence over embedded and extended)
 
-	client := fn.New(fn.WithRepositories("testdata/repositories"))
+	client := fn.New(fn.WithRepositoriesPath("testdata/repositories"))
 
 	runtimes, err := client.Runtimes()
 	if err != nil {

--- a/cmd/client.go
+++ b/cmd/client.go
@@ -13,11 +13,11 @@ import (
 )
 
 type ClientOptions struct {
-	Namespace    string
-	Registry     string
-	Repository   string
-	Repositories string
-	Verbose      bool
+	Namespace        string
+	Registry         string
+	Repository       string
+	RepositoriesPath string
+	Verbose          bool
 }
 
 type ClientFactory func(opts ClientOptions) *fn.Client
@@ -99,8 +99,8 @@ func NewDefaultClientFactory() (newClient ClientFactory, cleanUp func() error) {
 			fn.WithPusher(pusher),
 		}
 
-		if clientOptions.Repositories != "" {
-			opts = append(opts, fn.WithRepositories(clientOptions.Repositories)) // path to repositories in disk
+		if clientOptions.RepositoriesPath != "" {
+			opts = append(opts, fn.WithRepositoriesPath(clientOptions.RepositoriesPath)) // path to repositories in disk
 		}
 
 		return fn.New(opts...)

--- a/cmd/create_test.go
+++ b/cmd/create_test.go
@@ -122,8 +122,8 @@ func TestCreate_RepositoriesPath(t *testing.T) {
 	// will validate the test condition:  that config reflects the value of
 	// XDG_CONFIG_HOME, and secondarily the path suffix `func/repositories`.
 	cmd := NewCreateCmd(func(cfg ClientOptions) *fn.Client {
-		if cfg.Repositories != expected {
-			t.Fatalf("expected repositories default path to be '%v', got '%v'", expected, cfg.Repositories)
+		if cfg.RepositoriesPath != expected {
+			t.Fatalf("expected repositories default path to be '%v', got '%v'", expected, cfg.RepositoriesPath)
 		}
 		return fn.New()
 	})

--- a/cmd/repository.go
+++ b/cmd/repository.go
@@ -26,7 +26,7 @@ func newRepositoryClient(args []string) (repositoryConfig, RepositoryClient, err
 		return cfg, nil, err
 	}
 	client := repositoryClient{fn.New(
-		fn.WithRepositories(cfg.Repositories),
+		fn.WithRepositoriesPath(cfg.RepositoriesPath),
 		fn.WithVerbose(cfg.Verbose))}
 	return cfg, client, nil
 }
@@ -56,12 +56,6 @@ DESCRIPTION
 	flag.  Once added, a template from the repository can be used when creating
 	a new Function.
 
-	Alternative Repositories Location:
-	Repositories are stored on disk in ~/.config/func/repositories by default.
-	This location can be altered by either setting the FUNC_REPOSITORIES
-	environment variable, or by providing the --repositories (-r) flag to any
-	of the commands.  XDG_CONFIG_HOME is respected when determining the default.
-
 	Interactive Prompts:
 	To complete these commands interactively, pass the --confirm (-c) flag to
 	the 'repository' command, or any of the inidivual subcommands.
@@ -84,6 +78,12 @@ DESCRIPTION
 		$ {{.Name}} create -l go \
 			--template hello-world \
 			--repository https://github.com/boson-project/templates
+
+	Alternative Repositories Location:
+	Repositories are stored on disk in ~/.config/func/repositories by default.
+	This location can be altered by setting the FUNC_REPOSITORIES_PATH
+	environment variable.
+
 
 COMMANDS
 
@@ -118,7 +118,7 @@ COMMANDS
 	  entirely.  When in confirm mode (--confirm) it will confirm before
 	  deletion, but in regular mode this is done immediately, so please use
 	  caution, especially when using an altered repositories location
-	  (FUNC_REPOSITORIES environment variable or --repositories).
+	  (via the FUNC_REPOSITORIES_PATH environment variable).
 	    $ {{.Name}} repository remove <name>
 
 EXAMPLES
@@ -156,11 +156,10 @@ EXAMPLES
 	  default
 `,
 		SuggestFor: []string{"repositories", "repos", "template", "templates", "pack", "packs"},
-		PreRunE:    bindEnv("repositories", "confirm"),
+		PreRunE:    bindEnv("confirm"),
 	}
 
 	cmd.Flags().BoolP("confirm", "c", false, "Prompt to confirm all options interactively (Env: $FUNC_CONFIRM)")
-	cmd.Flags().StringP("repositories", "r", fn.RepositoriesPath(), "Path to language pack repositories (Env: $FUNC_REPOSITORIES)")
 
 	cmd.SetHelpFunc(defaultTemplatedHelp)
 
@@ -178,12 +177,9 @@ EXAMPLES
 
 func NewRepositoryListCmd(clientFn repositoryClientFn) *cobra.Command {
 	cmd := &cobra.Command{
-		Short:   "List repositories",
-		Use:     "list",
-		PreRunE: bindEnv("repositories"),
+		Short: "List repositories",
+		Use:   "list",
 	}
-
-	cmd.Flags().StringP("repositories", "r", fn.RepositoriesPath(), "Path to language pack repositories (Env: $FUNC_REPOSITORIES)")
 
 	cmd.RunE = func(_ *cobra.Command, args []string) error {
 		return runRepositoryList(args, clientFn)
@@ -196,11 +192,10 @@ func NewRepositoryAddCmd(clientFn repositoryClientFn) *cobra.Command {
 		Short:      "Add a repository",
 		Use:        "add <name> <url>",
 		SuggestFor: []string{"ad", "install"},
-		PreRunE:    bindEnv("repositories", "confirm"),
+		PreRunE:    bindEnv("confirm"),
 	}
 
 	cmd.Flags().BoolP("confirm", "c", false, "Prompt to confirm all options interactively (Env: $FUNC_CONFIRM)")
-	cmd.Flags().StringP("repositories", "r", fn.RepositoriesPath(), "Path to language pack repositories (Env: $FUNC_REPOSITORIES)")
 
 	cmd.RunE = func(_ *cobra.Command, args []string) error {
 		return runRepositoryAdd(args, clientFn)
@@ -212,11 +207,10 @@ func NewRepositoryRenameCmd(clientFn repositoryClientFn) *cobra.Command {
 	cmd := &cobra.Command{
 		Short:   "Rename a repository",
 		Use:     "rename <old> <new>",
-		PreRunE: bindEnv("repositories", "confirm"),
+		PreRunE: bindEnv("confirm"),
 	}
 
 	cmd.Flags().BoolP("confirm", "c", false, "Prompt to confirm all options interactively (Env: $FUNC_CONFIRM)")
-	cmd.Flags().StringP("repositories", "r", fn.RepositoriesPath(), "Path to language pack repositories (Env: $FUNC_REPOSITORIES)")
 
 	cmd.RunE = func(_ *cobra.Command, args []string) error {
 		return runRepositoryRename(args, clientFn)
@@ -230,11 +224,10 @@ func NewRepositoryRemoveCmd(clientFn repositoryClientFn) *cobra.Command {
 		Use:        "remove <name>",
 		Aliases:    []string{"rm"},
 		SuggestFor: []string{"delete", "del"},
-		PreRunE:    bindEnv("repositories", "confirm"),
+		PreRunE:    bindEnv("confirm"),
 	}
 
 	cmd.Flags().BoolP("confirm", "c", false, "Prompt to confirm all options interactively (Env: $FUNC_CONFIRM)")
-	cmd.Flags().StringP("repositories", "r", fn.RepositoriesPath(), "Path to language pack repositories (Env: $FUNC_REPOSITORIES)")
 
 	cmd.RunE = func(_ *cobra.Command, args []string) error {
 		return runRepositoryRemove(args, clientFn)
@@ -580,9 +573,9 @@ func installedRepositories(client RepositoryClient) ([]string, error) {
 
 // repositoryConfig used for instantiating a fn.Client
 type repositoryConfig struct {
-	Repositories string // Path to repos to be managed
-	Verbose      bool   // Enables verbose logging
-	Confirm      bool   // Enables interactive confirmation/prompting mode
+	RepositoriesPath string // Path to repos to be managed
+	Verbose          bool   // Enables verbose logging
+	Confirm          bool   // Enables interactive confirmation/prompting mode
 }
 
 // newRepositoryConfig creates a configuration suitable for use instantiating the
@@ -593,9 +586,15 @@ func newRepositoryConfig(args []string) (cfg repositoryConfig, err error) {
 	// first populated by static defaults, then environment variables,
 	// finally command flags.
 	cfg = repositoryConfig{
-		Repositories: viper.GetString("repositories"),
-		Verbose:      viper.GetBool("verbose"),
-		Confirm:      viper.GetBool("confirm"),
+		Verbose: viper.GetBool("verbose"),
+		Confirm: viper.GetBool("confirm"),
+	}
+
+	// Repositories Path
+	// Use env var to alter the default of ~/.config/func/repositories
+	cfg.RepositoriesPath = os.Getenv("FUNC_REPOSITORIES_PATH")
+	if cfg.RepositoriesPath == "" {
+		cfg.RepositoriesPath = fn.New().RepositoriesPath()
 	}
 
 	// If not in confirm (interactive prompting) mode,
@@ -612,7 +611,7 @@ func newRepositoryConfig(args []string) (cfg repositoryConfig, err error) {
 
 	// Noninteractive terminals in confirm/prompt mode simply echo
 	// effective values to stdout.
-	fmt.Fprintf(os.Stdout, "Repositories path: %v\n", cfg.Repositories)
+	fmt.Fprintf(os.Stdout, "Repositories path: %v\n", cfg.RepositoriesPath)
 	fmt.Fprintf(os.Stdout, "Verbose logging:   %v\n", cfg.Verbose)
 	return
 }
@@ -639,7 +638,7 @@ func (c repositoryConfig) prompt() (repositoryConfig, error) {
 			Name: "Repositories",
 			Prompt: &survey.Input{
 				Message: "Path to repositories:",
-				Default: c.Repositories,
+				Default: c.RepositoriesPath,
 			},
 			Validate: survey.Required,
 		}, {

--- a/docs/guides/commands.md
+++ b/docs/guides/commands.md
@@ -235,15 +235,14 @@ $ func repository -c
 ```
 
 Manages template repositories installed on disk at either the default location
-(~/.config/func/repositories) or the location specified by the --repository
-flag.  Once added, a template from the repository can be used when creating
-a new Function.
+(~/.config/func/repositories) or the location specified by the
+FUNC_REPOSITORIES_PATH environment variable.  Once added, a template from the
+repository can be used when creating a new Function.
 
 _Alternative Repositories Location:_
 Repositories are stored on disk in ~/.config/func/repositories by default.
-This location can be altered by either setting the FUNC_REPOSITORIES
-environment variable, or by providing the --repositories (-r) flag to any
-of the commands.  XDG_CONFIG_HOME is respected when determining the default.
+This location can be altered by setting the FUNC_REPOSITORIES_PATH
+environment variable.  XDG_CONFIG_HOME is respected when determining the default.
 
 _Interactive Prompts:_
 To complete these commands interactively, pass the --confirm (-c) flag to
@@ -309,7 +308,7 @@ Remove a repository by name.  Removes the repository from local storage
 entirely.  When in confirm mode (--confirm) it will confirm before
 deletion, but in regular mode this is done immediately, so please use
 caution, especially when using an altered repositories location
-(FUNC_REPOSITORIES environment variable or --repositories).
+(FUNC_REPOSITORIES_PATH environment variable).
 ```console
 $ func repository remove <name>
 ```

--- a/repositories_test.go
+++ b/repositories_test.go
@@ -27,7 +27,7 @@ func TestRepositories_List(t *testing.T) {
 	root, rm := Mktemp(t)
 	defer rm()
 
-	client := fn.New(fn.WithRepositories(root)) // Explicitly empty
+	client := fn.New(fn.WithRepositoriesPath(root)) // Explicitly empty
 
 	rr, err := client.Repositories().List()
 	if err != nil {
@@ -42,7 +42,7 @@ func TestRepositories_List(t *testing.T) {
 // TestRepositories_GetInvalid ensures that attempting to get an invalid repo
 // results in error.
 func TestRepositories_GetInvalid(t *testing.T) {
-	client := fn.New(fn.WithRepositories("testdata/repositories"))
+	client := fn.New(fn.WithRepositoriesPath("testdata/repositories"))
 
 	// invalid should error
 	_, err := client.Repositories().Get("invalid")
@@ -53,7 +53,7 @@ func TestRepositories_GetInvalid(t *testing.T) {
 
 // TestRepositories_Get ensures a repository can be accessed by name.
 func TestRepositories_Get(t *testing.T) {
-	client := fn.New(fn.WithRepositories("testdata/repositories"))
+	client := fn.New(fn.WithRepositoriesPath("testdata/repositories"))
 
 	// valid should not error
 	repo, err := client.Repositories().Get("customTemplateRepo")
@@ -78,7 +78,7 @@ func TestRepositories_All(t *testing.T) {
 	root, rm := Mktemp(t)
 	defer rm()
 
-	client := fn.New(fn.WithRepositories(root))
+	client := fn.New(fn.WithRepositoriesPath(root))
 
 	// Assert initially only the default is included
 	rr, err := client.Repositories().All()
@@ -121,7 +121,7 @@ func TestRepositories_Add(t *testing.T) {
 
 	// Instantiate the client using the current temp directory as the
 	// repositories' root location.
-	client := fn.New(fn.WithRepositories(root))
+	client := fn.New(fn.WithRepositoriesPath(root))
 
 	// Add the repository, explicitly specifying a name.  See other tests for
 	// defaulting from repository names and manifest-defined name.
@@ -161,7 +161,7 @@ func TestRepositories_AddDeafultName(t *testing.T) {
 	root, rm := Mktemp(t)
 	defer rm()
 
-	client := fn.New(fn.WithRepositories(root))
+	client := fn.New(fn.WithRepositoriesPath(root))
 
 	name, err := client.Repositories().Add("", uri)
 	if err != nil {
@@ -200,7 +200,7 @@ func TestRepositories_AddWithManifest(t *testing.T) {
 	root, rm := Mktemp(t)
 	defer rm()
 
-	client := fn.New(fn.WithRepositories(root))
+	client := fn.New(fn.WithRepositoriesPath(root))
 
 	name, err := client.Repositories().Add("", uri)
 	if err != nil {
@@ -237,7 +237,7 @@ func TestRepositories_AddExistingErrors(t *testing.T) {
 
 	// Instantiate the client using the current temp directory as the
 	// repositories' root location.
-	client := fn.New(fn.WithRepositories(root))
+	client := fn.New(fn.WithRepositoriesPath(root))
 
 	// Add twice.
 	name := "example"
@@ -275,7 +275,7 @@ func TestRepositories_Rename(t *testing.T) {
 
 	// Instantiate the client using the current temp directory as the
 	// repositories' root location.
-	client := fn.New(fn.WithRepositories(root))
+	client := fn.New(fn.WithRepositoriesPath(root))
 
 	// Add and Rename
 	if _, err := client.Repositories().Add("foo", uri); err != nil {
@@ -309,7 +309,7 @@ func TestRepositories_Remove(t *testing.T) {
 
 	// Instantiate the client using the current temp directory as the
 	// repositories' root location.
-	client := fn.New(fn.WithRepositories(root))
+	client := fn.New(fn.WithRepositoriesPath(root))
 
 	// Add and Remove
 	name := "example"
@@ -349,7 +349,7 @@ func TestRepositories_URL(t *testing.T) {
 	root, rm := Mktemp(t)
 	defer rm()
 
-	client := fn.New(fn.WithRepositories(root))
+	client := fn.New(fn.WithRepositoriesPath(root))
 
 	// Add the test repo
 	_, err := client.Repositories().Add("newrepo", uri)

--- a/repository_test.go
+++ b/repository_test.go
@@ -14,7 +14,7 @@ import (
 // TestRepository_TemplatesPath ensures that repositories can specify
 // an alternate location for templates using a manifest.
 func TestRepository_TemplatesPath(t *testing.T) {
-	client := fn.New(fn.WithRepositories("testdata/repositories"))
+	client := fn.New(fn.WithRepositoriesPath("testdata/repositories"))
 
 	// The repo ./testdata/repositories/customLanguagePackRepo includes a
 	// manifest.yaml which defines templates as existing in the ./templates
@@ -39,7 +39,7 @@ func TestRepository_TemplatesPath(t *testing.T) {
 // and template level.  The tests check for both embedded structures:
 // HealthEndpoints BuildConfig.
 func TestRepository_Inheritance(t *testing.T) {
-	client := fn.New(fn.WithRepositories("testdata/repositories"))
+	client := fn.New(fn.WithRepositoriesPath("testdata/repositories"))
 
 	// The repo ./testdata/repositories/customLanguagePack includes a manifest
 	// which defines custom readiness and liveness endpoints.

--- a/templates_test.go
+++ b/templates_test.go
@@ -22,7 +22,7 @@ import (
 func TestTemplates_List(t *testing.T) {
 	// A client which specifies a location of exensible repositoreis on disk
 	// will list all builtin plus exensible
-	client := fn.New(fn.WithRepositories("testdata/repositories"))
+	client := fn.New(fn.WithRepositoriesPath("testdata/repositories"))
 
 	// list templates for the "go" runtime
 	templates, err := client.Templates().List("go")
@@ -49,7 +49,7 @@ func TestTemplates_List(t *testing.T) {
 // when retrieving the list of templates for a runtime that does not exist
 // in an extended repository, but does in the default.
 func TestTemplates_List_ExtendedNotFound(t *testing.T) {
-	client := fn.New(fn.WithRepositories("testdata/repositories"))
+	client := fn.New(fn.WithRepositoriesPath("testdata/repositories"))
 
 	// list templates for the "python" runtime -
 	// not supplied by the extended repos
@@ -71,7 +71,7 @@ func TestTemplates_List_ExtendedNotFound(t *testing.T) {
 // TestTemplates_Get ensures that a template's metadata object can
 // be retrieved by full name (full name prefix optional for embedded).
 func TestTemplates_Get(t *testing.T) {
-	client := fn.New(fn.WithRepositories("testdata/repositories"))
+	client := fn.New(fn.WithRepositoriesPath("testdata/repositories"))
 
 	// Check embedded
 	embedded, err := client.Templates().Get("go", "http")
@@ -135,7 +135,7 @@ func TestTemplates_Custom(t *testing.T) {
 	// at: testdata/repositories/[provider]/[runtime]/[template]
 	client := fn.New(
 		fn.WithRegistry(TestRegistry),
-		fn.WithRepositories("testdata/repositories"))
+		fn.WithRepositoriesPath("testdata/repositories"))
 
 	// Create a function specifying a template from
 	// the custom provider's directory in the on-disk template repo.
@@ -306,7 +306,7 @@ func TestTemplates_ModeCustom(t *testing.T) {
 
 	client := fn.New(
 		fn.WithRegistry(TestRegistry),
-		fn.WithRepositories("testdata/repositories"))
+		fn.WithRepositoriesPath("testdata/repositories"))
 
 	// Write executable from custom repo
 	err := client.Create(fn.Function{
@@ -392,7 +392,7 @@ func TestTemplates_RuntimeManifestBuildEnvs(t *testing.T) {
 	// Client whose internal templates will be used.
 	client := fn.New(
 		fn.WithRegistry(TestRegistry),
-		fn.WithRepositories("testdata/repositories"))
+		fn.WithRepositoriesPath("testdata/repositories"))
 
 	// write out a template
 	err := client.Create(fn.Function{
@@ -439,7 +439,7 @@ func TestTemplates_ManifestBuildEnvs(t *testing.T) {
 	// Client whose internal templates will be used.
 	client := fn.New(
 		fn.WithRegistry(TestRegistry),
-		fn.WithRepositories("testdata/repositories"))
+		fn.WithRepositoriesPath("testdata/repositories"))
 
 	// write out a template
 	err := client.Create(fn.Function{
@@ -486,7 +486,7 @@ func TestTemplates_RepositoryManifestBuildEnvs(t *testing.T) {
 	// Client whose internal templates will be used.
 	client := fn.New(
 		fn.WithRegistry(TestRegistry),
-		fn.WithRepositories("testdata/repositories"))
+		fn.WithRepositoriesPath("testdata/repositories"))
 
 	// write out a template
 	err := client.Create(fn.Function{
@@ -531,7 +531,7 @@ func TestTemplates_ManifestInvocationHints(t *testing.T) {
 
 	client := fn.New(
 		fn.WithRegistry(TestRegistry),
-		fn.WithRepositories("testdata/repositories"))
+		fn.WithRepositoriesPath("testdata/repositories"))
 
 	err := client.Create(fn.Function{
 		Root:     root,
@@ -562,7 +562,7 @@ func TestTemplates_ManifestRemoved(t *testing.T) {
 	// Client whose internal templates will be used.
 	client := fn.New(
 		fn.WithRegistry(TestRegistry),
-		fn.WithRepositories("testdata/repositories"))
+		fn.WithRepositoriesPath("testdata/repositories"))
 
 	// write out a template
 	err := client.Create(fn.Function{
@@ -596,7 +596,7 @@ func TestTemplates_InvocationDefault(t *testing.T) {
 
 	client := fn.New(
 		fn.WithRegistry(TestRegistry),
-		fn.WithRepositories("testdata/repositories"))
+		fn.WithRepositoriesPath("testdata/repositories"))
 
 	// The customTemplateRepo explicitly does not
 	// include manifests as it exemplifies an entirely default template repo.


### PR DESCRIPTION

:broom: Rename Repositories to RepositoriesPath
:broom: Relegates RepositoriesPath to an environment-varible-only setting

/kind cleanup

Fixes #896 
