### PR TITLE
fix: full clone of template repos on add

### DIFF
--- a/repositories_test.go
+++ b/repositories_test.go
@@ -338,11 +338,8 @@ func TestRepositories_Remove(t *testing.T) {
 // TestRepositories_URL ensures that a repository populates its URL member
 // from the git repository's origin url (if it is a git repo and exists)
 func TestRepositories_URL(t *testing.T) {
-	// FIXME:  This test is temporarily disabled.  See not in Repository.Write
-	// in short: as a side-effect of removing the double-clone, the in-memory
-	// repo is insufficient as it does not include a .git directory.
-	if true {
-		return
+	if runtime.GOOS == "windows" {
+		t.Skip("TODO fix this test on Windows CI") // TODO fix this
 	}
 
 	uri := TestRepoURI(RepositoriesTestRepo, t)

--- a/repository.go
+++ b/repository.go
@@ -500,7 +500,7 @@ func (r *Repository) URL() string {
 
 	// git.PlainOpen does not seem to
 	if strings.HasPrefix(uri, "file://") {
-		uri = r.uri[6:]
+		uri = filepath.FromSlash(r.uri[7:])
 	}
 
 	repo, err := git.PlainOpen(uri)


### PR DESCRIPTION
# Changes

- :bug: Repositories missing .git

Repositories added via `func repo add ...` were missing the .git directory when installed locally.  The intent of `func repo add` was to be functionally equivalent to a `git clone`, so missing the .git directory is a bug.  This is evidenced by the downstream bug that reading metadata, such as the source URL, failed due to the missing metadata directory.

Note that existing (installed) repositories will need to be removed and re-added to be correctly installed.

This fixes the aforementioned problem of a missing remote URL when listing repositories in verbose mode (#891)

/kind bug

Fixes #891
