### PR TITLE
Clean up container when `func run` SIGKILLed

### DIFF
--- a/client_test.go
+++ b/client_test.go
@@ -1125,7 +1125,7 @@ func TestClient_Invoke_HTTP(t *testing.T) {
 		_, p, _ := net.SplitHostPort(l.Addr().String())
 		errs := make(chan error, 10)
 		stop := func() {}
-		return fn.NewJob(f, p, errs, stop)
+		return fn.NewJob(f, "ctr", p, errs, stop)
 	}
 	client := fn.New(fn.WithRegistry(TestRegistry), fn.WithRunner(runner))
 
@@ -1219,7 +1219,7 @@ func TestClient_Invoke_CloudEvent(t *testing.T) {
 		_, p, _ := net.SplitHostPort(l.Addr().String())
 		errs := make(chan error, 10)
 		stop := func() {}
-		return fn.NewJob(f, p, errs, stop)
+		return fn.NewJob(f, "ctr", p, errs, stop)
 	}
 	client := fn.New(fn.WithRegistry(TestRegistry), fn.WithRunner(runner))
 
@@ -1267,7 +1267,7 @@ func TestClient_Instances(t *testing.T) {
 	runner.RunFn = func(_ context.Context, f fn.Function) (*fn.Job, error) {
 		errs := make(chan error, 10)
 		stop := func() {}
-		return fn.NewJob(f, "8080", errs, stop)
+		return fn.NewJob(f, "ctr", "8080", errs, stop)
 	}
 
 	// Client with the mock runner

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -98,6 +98,7 @@ EXAMPLES
 	cmd.AddCommand(NewRunCmd(newClient))
 	cmd.AddCommand(NewCompletionCmd())
 	cmd.AddCommand(NewVersionCmd(config.Version))
+	cmd.AddCommand(NewWatchRemoveCmd())
 
 	// Help
 	// Overridden to process the help text as a template and have

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"os"
+	"os/exec"
 
 	"github.com/ory/viper"
 	"github.com/spf13/cobra"
@@ -94,6 +96,11 @@ func runRun(cmd *cobra.Command, args []string, newClient ClientFactory) (err err
 		return
 	}
 	defer job.Stop()
+
+	pid := os.Getpid()
+
+	watcher := exec.Command(os.Args[0], "watch-remove", fmt.Sprintf("--pid=%d", pid), fmt.Sprintf("--ctr=%s", job.ContainerID))
+	watcher.Start()
 
 	fmt.Fprintf(cmd.OutOrStderr(), "Function started on port %v\n", job.Port)
 

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -100,7 +100,10 @@ func runRun(cmd *cobra.Command, args []string, newClient ClientFactory) (err err
 	pid := os.Getpid()
 
 	watcher := exec.Command(os.Args[0], "watch-remove", fmt.Sprintf("--pid=%d", pid), fmt.Sprintf("--ctr=%s", job.ContainerID))
-	watcher.Start()
+	err = watcher.Start()
+	if err != nil {
+		return fmt.Errorf("failed to start 'watch-remove': %w", err)
+	}
 
 	fmt.Fprintf(cmd.OutOrStderr(), "Function started on port %v\n", job.Port)
 

--- a/cmd/wait_pid_darwin.go
+++ b/cmd/wait_pid_darwin.go
@@ -1,0 +1,25 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+	"syscall"
+	"time"
+)
+
+// TODO there should be a better way for darwin/bsd using kqueue
+func waitProcess(pid int) error {
+	proc, err := os.FindProcess(pid)
+	if err != nil {
+		return fmt.Errorf("failed to find the process: %w", err)
+	}
+	defer proc.Release()
+	for {
+		err = proc.Signal(syscall.Signal(0))
+		if err != nil {
+			break
+		}
+		time.Sleep(time.Millisecond * 50)
+	}
+	return nil
+}

--- a/cmd/wait_pid_linux.go
+++ b/cmd/wait_pid_linux.go
@@ -1,0 +1,31 @@
+package cmd
+
+import (
+	"fmt"
+	"golang.org/x/sys/unix"
+	"syscall"
+)
+
+const (
+	sysPidFDOpen = 434
+)
+
+func waitProcess(pid int) error {
+	fd, _, e := syscall.Syscall(sysPidFDOpen, uintptr(pid), 0, 0)
+	if e != 0 {
+		return fmt.Errorf("failed to open the pid fd: %w", e)
+	}
+
+	pollFDs := []unix.PollFd{{Fd: int32(fd), Events: unix.POLLIN}}
+	for {
+		n, err := unix.Poll(pollFDs, 1_000)
+		if err != nil {
+			return fmt.Errorf("failed to poll on the pid fd: %w", err)
+		}
+		if n == 1 {
+			if pollFDs[0].Revents != 0 {
+				return nil
+			}
+		}
+	}
+}

--- a/cmd/wait_pid_linux.go
+++ b/cmd/wait_pid_linux.go
@@ -2,8 +2,9 @@ package cmd
 
 import (
 	"fmt"
-	"golang.org/x/sys/unix"
 	"syscall"
+
+	"golang.org/x/sys/unix"
 )
 
 const (

--- a/cmd/wait_pid_windows.go
+++ b/cmd/wait_pid_windows.go
@@ -1,0 +1,24 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+)
+
+func waitProcess(pid int) error {
+	proc, err := os.FindProcess(pid)
+	if err != nil {
+		return fmt.Errorf("failed to find the process: %w", err)
+	}
+	defer proc.Release()
+
+	for {
+		ps, err := proc.Wait()
+		if err != nil {
+			return fmt.Errorf("failed to wait for the process: %w", err)
+		}
+		if ps.Exited() {
+			return nil
+		}
+	}
+}

--- a/cmd/watch_remove.go
+++ b/cmd/watch_remove.go
@@ -2,10 +2,10 @@ package cmd
 
 import (
 	"fmt"
-	"github.com/docker/docker/client"
 	"time"
 
 	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/client"
 	"github.com/spf13/cobra"
 
 	"knative.dev/kn-plugin-func/docker"

--- a/cmd/watch_remove.go
+++ b/cmd/watch_remove.go
@@ -1,0 +1,60 @@
+package cmd
+
+import (
+	"fmt"
+	"github.com/docker/docker/client"
+	"time"
+
+	"github.com/docker/docker/api/types"
+	"github.com/spf13/cobra"
+
+	"knative.dev/kn-plugin-func/docker"
+)
+
+// NewWatchRemoveCmd returns new hidden command that is executed by the run sub-command (see NewRunCmd).
+// Users shouldn't invoke this command by themselves.
+// This command watches parental `func run` process specified by the `--pid` flag.
+// When the parental process exits it removes container specified by the `--ctr` flag.
+// This is used to ensure container cleanup even if the `func run` has been closed forcefully (e.g. SIGKILL).
+func NewWatchRemoveCmd() *cobra.Command {
+	var ctrID string
+	var pid int
+
+	var cmd = cobra.Command{
+		Use:    "watch-remove",
+		Hidden: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+
+			err := waitProcess(pid)
+			if err != nil {
+				return fmt.Errorf("failed to wait for the process: %w", err)
+			}
+
+			c, _, err := docker.NewClient(client.DefaultDockerHost)
+			if err != nil {
+				return fmt.Errorf("failed to create docker client: %w", err)
+			}
+
+			var timeout = time.Second * 10
+			if err = c.ContainerStop(cmd.Context(), ctrID, &timeout); err != nil {
+				return fmt.Errorf("failed to stop the container %q: %w", ctrID, err)
+			}
+			if err = c.ContainerRemove(cmd.Context(), ctrID, types.ContainerRemoveOptions{}); err != nil {
+				return fmt.Errorf("failed to stop the container %q: %w", ctrID, err)
+			}
+			return nil
+		},
+	}
+	cmd.Flags().StringVarP(&ctrID, "ctr", "c", "", "container id to be removed")
+	cmd.Flags().IntVarP(&pid, "pid", "p", -1, "pid to be watched")
+	err := cmd.MarkFlagRequired("ctr")
+	if err != nil {
+		panic(err)
+	}
+	err = cmd.MarkFlagRequired("pid")
+	if err != nil {
+		panic(err)
+	}
+
+	return &cmd
+}

--- a/docker/runner.go
+++ b/docker/runner.go
@@ -122,7 +122,7 @@ func (n *Runner) Run(ctx context.Context, f fn.Function) (job *fn.Job, err error
 	}
 
 	// Job reporting port, runtime errors and provides a mechanism for stopping.
-	return fn.NewJob(f, port, runtimeErrCh, stop)
+	return fn.NewJob(f, id, port, runtimeErrCh, stop)
 }
 
 // Dial the given (tcp) port on the given interface, returning an error if it is

--- a/go.mod
+++ b/go.mod
@@ -31,6 +31,7 @@ require (
 	github.com/tektoncd/pipeline v0.32.1
 	github.com/whilp/git-urls v1.0.0
 	golang.org/x/crypto v0.0.0-20210921155107-089bfa567519
+	golang.org/x/sys v0.0.0-20220128215802-99c3d69c2c27
 	golang.org/x/term v0.0.0-20210927222741-03fcf44c2211
 	gopkg.in/natefinch/npipe.v2 v2.0.0-20160621034901-c1b8fa8bdcce
 	gopkg.in/yaml.v2 v2.4.0

--- a/job.go
+++ b/job.go
@@ -15,21 +15,23 @@ const (
 // Job represents a running Function job (presumably started by this process'
 // Runner instance.
 type Job struct {
-	Function Function
-	Port     string
-	Errors   chan error
-	onStop   func()
+	Function    Function
+	ContainerID string
+	Port        string
+	Errors      chan error
+	onStop      func()
 }
 
 // Create a new Job which represents a running Function task by providing
 // the port on which it was started, a channel on which runtime errors can
 // be received, and a stop function.
-func NewJob(f Function, port string, errs chan error, onStop func()) (*Job, error) {
+func NewJob(f Function, containerID, port string, errs chan error, onStop func()) (*Job, error) {
 	j := &Job{
-		Function: f,
-		Port:     port,
-		Errors:   errs,
-		onStop:   onStop,
+		Function:    f,
+		ContainerID: containerID,
+		Port:        port,
+		Errors:      errs,
+		onStop:      onStop,
 	}
 	return j, j.save() // Everything is a file:  save instance data to disk.
 }

--- a/mock/runner.go
+++ b/mock/runner.go
@@ -21,7 +21,7 @@ func NewRunner() *Runner {
 		RunFn: func(ctx context.Context, f fn.Function) (*fn.Job, error) {
 			errs := make(chan error, 1)
 			stop := func() {}
-			return fn.NewJob(f, "8080", errs, stop)
+			return fn.NewJob(f, "ctr", "8080", errs, stop)
 		},
 	}
 }

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -798,6 +798,7 @@ golang.org/x/oauth2/jwt
 golang.org/x/sync/errgroup
 golang.org/x/sync/semaphore
 # golang.org/x/sys v0.0.0-20220128215802-99c3d69c2c27
+## explicit
 golang.org/x/sys/cpu
 golang.org/x/sys/execabs
 golang.org/x/sys/internal/unsafeheader


### PR DESCRIPTION
Clean up the function container even when `func run` is forcefully killed:

This changes introduces new hidden sub-command `watch-remove`.
The sub-command waits for exit of a process specified by a flag and then removes a container specified by another flag.
The sub-command shall not be run by users directly.

The `run` sub-command executes the `watch-remove` sub-command passing its pid to the sub-command and also passing ID of the created container.

When `func run` exits for whatever reason including SIGKILL or SEGFAULT the container should be removed by the child process (`watch-remove`).

resolves #767