### PR TITLE
chore: add Apple M1 build in cross-platform target

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -40,8 +40,12 @@ jobs:
       # Upload all build artifacts
       - uses: actions/upload-artifact@v2
         with:
-          name: OSX Binary
+          name: OSX Binary (AMD)
           path: func_darwin_amd64
+      - uses: actions/upload-artifact@v2
+        with:
+          name: OSX Binary (ARM)
+          path: func_darwin_arm64
       - uses: actions/upload-artifact@v2
         with:
           name: Linux Binary

--- a/Makefile
+++ b/Makefile
@@ -144,13 +144,11 @@ test-e2e: ## Run end-to-end tests using an available cluster.
 cross-platform: darwin-arm64 darwin-amd64 linux windows ## Build all distributable (cross-platform) binaries
 
 darwin-arm64: $(BIN_DARWIN_ARM64) ## Build for mac M1
-	env CGO_ENABLED=0 GOOS=darwin GOARCH=arm64 go build -o $(BIN_DARWIN_ARM64) -ldflags $(LDFLAGS) ./cmd/$(BIN)
 
 $(BIN_DARWIN_ARM64): zz_filesystem_generated.go
 	env CGO_ENABLED=0 GOOS=darwin GOARCH=arm64 go build -o $(BIN_DARWIN_ARM64) -ldflags $(LDFLAGS) ./cmd/$(BIN)
 
 darwin-amd64: $(BIN_DARWIN_AMD64) ## Build for Darwin (macOS)
-	env CGO_ENABLED=0 GOOS=darwin GOARCH=amd64 go build -o $(BIN_DARWIN_AMD64) -ldflags $(LDFLAGS) ./cmd/$(BIN)
 
 $(BIN_DARWIN_AMD64): zz_filesystem_generated.go
 	env CGO_ENABLED=0 GOOS=darwin GOARCH=amd64 go build -o $(BIN_DARWIN_AMD64) -ldflags $(LDFLAGS) ./cmd/$(BIN)

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,8 @@
 
 # Binaries
 BIN         := func
-BIN_DARWIN  ?= $(BIN)_darwin_amd64
+BIN_AMD64   ?= $(BIN)_darwin_amd64
+BIN_ARM64   ?= $(BIN)_darwin_arm64
 BIN_LINUX   ?= $(BIN)_linux_amd64
 BIN_WINDOWS ?= $(BIN)_windows_amd64.exe
 
@@ -88,7 +89,7 @@ zz_filesystem_generated.go: clean_templates
 .PHONY: clean
 
 clean: clean_templates ## Remove generated artifacts such as binaries and schemas
-	rm -f $(BIN) $(BIN_WINDOWS) $(BIN_LINUX) $(BIN_DARWIN)
+	rm -f $(BIN) $(BIN_WINDOWS) $(BIN_LINUX) $(BIN_AMD64) $(BIN_ARM64)
 	rm -f schema/func_yaml-schema.json
 	rm -f coverage.out
 
@@ -140,12 +141,19 @@ test-e2e: ## Run end-to-end tests using an available cluster.
 ##@ Release Artifacts
 ######################
 
-cross-platform: darwin linux windows ## Build all distributable (cross-platform) binaries
+cross-platform: darwin-arm64 darwin-amd64 linux windows ## Build all distributable (cross-platform) binaries
 
-darwin: $(BIN_DARWIN) ## Build for Darwin (macOS)
+darwin-arm64: $(BIN_ARM64) ## Build for mac M1
+	env CGO_ENABLED=0 GOOS=darwin GOARCH=arm64 go build -o $(BIN_ARM64) -ldflags $(LDFLAGS) ./cmd/$(BIN)
 
-$(BIN_DARWIN): zz_filesystem_generated.go
-	env CGO_ENABLED=0 GOOS=darwin GOARCH=amd64 go build -o $(BIN_DARWIN) -ldflags $(LDFLAGS) ./cmd/$(BIN)
+$(BIN_ARM64): zz_filesystem_generated.go
+	env CGO_ENABLED=0 GOOS=darwin GOARCH=arm64 go build -o $(BIN_ARM64) -ldflags $(LDFLAGS) ./cmd/$(BIN)
+
+darwin-amd64: $(BIN_AMD64) ## Build for Darwin (macOS)
+	env CGO_ENABLED=0 GOOS=darwin GOARCH=amd64 go build -o $(BIN_AMD64) -ldflags $(LDFLAGS) ./cmd/$(BIN)
+
+$(BIN_AMD64): zz_filesystem_generated.go
+	env CGO_ENABLED=0 GOOS=darwin GOARCH=amd64 go build -o $(BIN_AMD64) -ldflags $(LDFLAGS) ./cmd/$(BIN)
 
 linux: $(BIN_LINUX) ## Build for Linux
 

--- a/Makefile
+++ b/Makefile
@@ -6,8 +6,8 @@
 
 # Binaries
 BIN         := func
-BIN_AMD64   ?= $(BIN)_darwin_amd64
-BIN_ARM64   ?= $(BIN)_darwin_arm64
+BIN_DARWIN_AMD64   ?= $(BIN)_darwin_amd64
+BIN_DARWIN_ARM64   ?= $(BIN)_darwin_arm64
 BIN_LINUX   ?= $(BIN)_linux_amd64
 BIN_WINDOWS ?= $(BIN)_windows_amd64.exe
 
@@ -89,7 +89,7 @@ zz_filesystem_generated.go: clean_templates
 .PHONY: clean
 
 clean: clean_templates ## Remove generated artifacts such as binaries and schemas
-	rm -f $(BIN) $(BIN_WINDOWS) $(BIN_LINUX) $(BIN_AMD64) $(BIN_ARM64)
+	rm -f $(BIN) $(BIN_WINDOWS) $(BIN_LINUX) $(BIN_DARWIN_AMD64) $(BIN_DARWIN_ARM64)
 	rm -f schema/func_yaml-schema.json
 	rm -f coverage.out
 
@@ -143,17 +143,17 @@ test-e2e: ## Run end-to-end tests using an available cluster.
 
 cross-platform: darwin-arm64 darwin-amd64 linux windows ## Build all distributable (cross-platform) binaries
 
-darwin-arm64: $(BIN_ARM64) ## Build for mac M1
-	env CGO_ENABLED=0 GOOS=darwin GOARCH=arm64 go build -o $(BIN_ARM64) -ldflags $(LDFLAGS) ./cmd/$(BIN)
+darwin-arm64: $(BIN_DARWIN_ARM64) ## Build for mac M1
+	env CGO_ENABLED=0 GOOS=darwin GOARCH=arm64 go build -o $(BIN_DARWIN_ARM64) -ldflags $(LDFLAGS) ./cmd/$(BIN)
 
-$(BIN_ARM64): zz_filesystem_generated.go
-	env CGO_ENABLED=0 GOOS=darwin GOARCH=arm64 go build -o $(BIN_ARM64) -ldflags $(LDFLAGS) ./cmd/$(BIN)
+$(BIN_DARWIN_ARM64): zz_filesystem_generated.go
+	env CGO_ENABLED=0 GOOS=darwin GOARCH=arm64 go build -o $(BIN_DARWIN_ARM64) -ldflags $(LDFLAGS) ./cmd/$(BIN)
 
-darwin-amd64: $(BIN_AMD64) ## Build for Darwin (macOS)
-	env CGO_ENABLED=0 GOOS=darwin GOARCH=amd64 go build -o $(BIN_AMD64) -ldflags $(LDFLAGS) ./cmd/$(BIN)
+darwin-amd64: $(BIN_DARWIN_AMD64) ## Build for Darwin (macOS)
+	env CGO_ENABLED=0 GOOS=darwin GOARCH=amd64 go build -o $(BIN_DARWIN_AMD64) -ldflags $(LDFLAGS) ./cmd/$(BIN)
 
-$(BIN_AMD64): zz_filesystem_generated.go
-	env CGO_ENABLED=0 GOOS=darwin GOARCH=amd64 go build -o $(BIN_AMD64) -ldflags $(LDFLAGS) ./cmd/$(BIN)
+$(BIN_DARWIN_AMD64): zz_filesystem_generated.go
+	env CGO_ENABLED=0 GOOS=darwin GOARCH=amd64 go build -o $(BIN_DARWIN_AMD64) -ldflags $(LDFLAGS) ./cmd/$(BIN)
 
 linux: $(BIN_LINUX) ## Build for Linux
 


### PR DESCRIPTION
This commit adds a `make` target for `darwin-arm64` and changes the original `darwin` target to `darwin-amd64`.

Might fix: https://github.com/knative-sandbox/kn-plugin-func/issues/377

/kind chore

Signed-off-by: Lance Ball <lball@redhat.com>

**Release Note**
```release-note
Added support for Apple M1 native binary
```
