### PR TITLE
feat: on cluster build doesn't require privileged cluster permissions

### DIFF
--- a/pipelines/resources/tekton/task/func-buildpacks/0.1/func-buildpacks.yaml
+++ b/pipelines/resources/tekton/task/func-buildpacks/0.1/func-buildpacks.yaml
@@ -1,0 +1,195 @@
+---
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: func-buildpacks
+  labels:
+    app.kubernetes.io/version: "0.1"
+  annotations:
+    tekton.dev/categories: Image Build
+    tekton.dev/pipelines.minVersion: "0.17.0"
+    tekton.dev/tags: image-build
+    tekton.dev/displayName: "Knative Functions Buildpacks"
+    tekton.dev/platforms: "linux/amd64"
+spec:
+  description: >-
+    The Knative Functions Buildpacks task builds source into a container image and pushes it to a registry,
+    using Cloud Native Buildpacks. This task is based on the Buildpacks Tekton task v 0.4.
+
+  workspaces:
+    - name: source
+      description: Directory where application source is located.
+    - name: cache
+      description: Directory where cache is stored (when no cache image is provided).
+      optional: true
+    - name: dockerconfig
+      description: >-
+        An optional workspace that allows providing a .docker/config.json file
+        for Buildpacks lifecycle binary to access the container registry.
+        The file should be placed at the root of the Workspace with name config.json.
+      optional: true
+
+  params:
+    - name: APP_IMAGE
+      description: The name of where to store the app image.
+    - name: BUILDER_IMAGE
+      description: The image on which builds will run (must include lifecycle and compatible buildpacks).
+    - name: SOURCE_SUBPATH
+      description: A subpath within the `source` input where the source to build is located.
+      default: ""
+    - name: ENV_VARS
+      type: array
+      description: Environment variables to set during _build-time_.
+      default: []
+    - name: PROCESS_TYPE
+      description: The default process type to set on the image.
+      default: "web"
+    - name: RUN_IMAGE
+      description: Reference to a run image to use.
+      default: ""
+    - name: CACHE_IMAGE
+      description: The name of the persistent app cache image (if no cache workspace is provided).
+      default: ""
+    - name: SKIP_RESTORE
+      description: Do not write layer metadata or restore cached layers.
+      default: "false"
+    - name: USER_ID
+      description: The user ID of the builder image user.
+      default: "1000"
+    - name: GROUP_ID
+      description: The group ID of the builder image user.
+      default: "1000"
+    - name: PLATFORM_DIR
+      description: The name of the platform directory.
+      default: empty-dir
+
+  results:
+    - name: APP_IMAGE_DIGEST
+      description: The digest of the built `APP_IMAGE`.
+
+  stepTemplate:
+    env:
+      - name: CNB_PLATFORM_API
+        value: "0.4"
+
+  steps:
+    - name: prepare
+      image: docker.io/library/bash:5.1.4@sha256:b208215a4655538be652b2769d82e576bc4d0a2bb132144c060efc5be8c3f5d6
+      args:
+        - "--env-vars"
+        - "$(params.ENV_VARS[*])"
+      script: |
+        #!/usr/bin/env bash
+        set -e
+
+        if [[ "$(workspaces.cache.bound)" == "true" ]]; then
+          echo "> Setting permissions on '$(workspaces.cache.path)'..."
+          chown -R "$(params.USER_ID):$(params.GROUP_ID)" "$(workspaces.cache.path)"
+        fi
+
+        for path in "/tekton/home" "/layers" "$(workspaces.source.path)"; do
+          echo "> Setting permissions on '$path'..."
+          chown -R "$(params.USER_ID):$(params.GROUP_ID)" "$path"
+
+          if [[ "$path" == "$(workspaces.source.path)" ]]; then
+              chmod 775 "$(workspaces.source.path)"
+          fi
+        done
+
+        echo "> Parsing additional configuration..."
+        parsing_flag=""
+        envs=()
+        for arg in "$@"; do
+            if [[ "$arg" == "--env-vars" ]]; then
+                echo "-> Parsing env variables..."
+                parsing_flag="env-vars"
+            elif [[ "$parsing_flag" == "env-vars" ]]; then
+                envs+=("$arg")
+            fi
+        done
+
+        echo "> Processing any environment variables..."
+        ENV_DIR="/platform/env"
+
+        echo "--> Creating 'env' directory: $ENV_DIR"
+        mkdir -p "$ENV_DIR"
+
+        for env in "${envs[@]}"; do
+            IFS='=' read -r key value string <<< "$env"
+            if [[ "$key" != "" && "$value" != "" ]]; then
+                path="${ENV_DIR}/${key}"
+                echo "--> Writing ${path}..."
+                echo -n "$value" > "$path"
+            fi
+        done
+      volumeMounts:
+        - name: layers-dir
+          mountPath: /layers
+        - name: $(params.PLATFORM_DIR)
+          mountPath: /platform
+
+    - name: create
+      image: $(params.BUILDER_IMAGE)
+      imagePullPolicy: Always
+      command: ["/cnb/lifecycle/creator"]
+      env:
+        - name: DOCKER_CONFIG
+          value: $(workspaces.dockerconfig.path)
+      args:
+        - "-app=$(workspaces.source.path)/$(params.SOURCE_SUBPATH)"
+        - "-cache-dir=$(workspaces.cache.path)"
+        - "-cache-image=$(params.CACHE_IMAGE)"
+        - "-uid=$(params.USER_ID)"
+        - "-gid=$(params.GROUP_ID)"
+        - "-layers=/layers"
+        - "-platform=/platform"
+        - "-report=/layers/report.toml"
+        - "-process-type=$(params.PROCESS_TYPE)"
+        - "-skip-restore=$(params.SKIP_RESTORE)"
+        - "-previous-image=$(params.APP_IMAGE)"
+        - "-run-image=$(params.RUN_IMAGE)"
+        - "$(params.APP_IMAGE)"
+      volumeMounts:
+        - name: layers-dir
+          mountPath: /layers
+        - name: $(params.PLATFORM_DIR)
+          mountPath: /platform
+      securityContext:
+        runAsUser: 1000
+        runAsGroup: 1000
+
+    - name: results
+      image: docker.io/library/bash:5.1.4@sha256:b208215a4655538be652b2769d82e576bc4d0a2bb132144c060efc5be8c3f5d6
+      script: |
+        #!/usr/bin/env bash
+        set -e
+        cat /layers/report.toml | grep "digest" | cut -d'"' -f2 | cut -d'"' -f2 | tr -d '\n' | tee $(results.APP_IMAGE_DIGEST.path)
+
+        ############################################
+        ##### Added part for Knative Functions #####
+        ############################################
+
+        digest=$(cat $(results.APP_IMAGE_DIGEST.path))
+
+        func_file="$(workspaces.source.path)/func.yaml"
+        if [ "$(params.SOURCE_SUBPATH)" != "" ]; then
+          func_file="$(workspaces.source.path)/$(params.SOURCE_SUBPATH)/func.yaml"
+        fi
+
+        echo ""
+        sed -i "s|^image:.*$|image: $(params.APP_IMAGE)|" "$func_file"
+        echo "Function image name: $(params.APP_IMAGE)"
+
+        sed -i "s/^imageDigest:.*$/imageDigest: $digest/" "$func_file"
+        echo "Function image digest: $digest"
+
+        ############################################
+      volumeMounts:
+        - name: layers-dir
+          mountPath: /layers
+
+  volumes:
+    - name: empty-dir
+      emptyDir: {}
+    - name: layers-dir
+      emptyDir: {}

--- a/pipelines/tekton/client.go
+++ b/pipelines/tekton/client.go
@@ -14,18 +14,23 @@ const (
 	DefaultWaitingTimeout = 120 * time.Second
 )
 
-func NewTektonClient() (*v1beta1.TektonV1beta1Client, error) {
+func NewTektonClientAndResolvedNamespace(defaultNamespace string) (*v1beta1.TektonV1beta1Client, string, error) {
+	namespace, err := k8s.GetNamespace(defaultNamespace)
+	if err != nil {
+		return nil, "", err
+	}
+
 	restConfig, err := k8s.GetClientConfig().ClientConfig()
 	if err != nil {
-		return nil, fmt.Errorf("failed to create new tekton client: %w", err)
+		return nil, "", fmt.Errorf("failed to create new tekton client: %w", err)
 	}
 
 	client, err := v1beta1.NewForConfig(restConfig)
 	if err != nil {
-		return nil, fmt.Errorf("failed to create new tekton client: %v", err)
+		return nil, "", fmt.Errorf("failed to create new tekton client: %v", err)
 	}
 
-	return client, nil
+	return client, namespace, nil
 }
 
 func NewTektonClientset() (versioned.Interface, error) {

--- a/pipelines/tekton/tasks.go
+++ b/pipelines/tekton/tasks.go
@@ -2,12 +2,17 @@ package tekton
 
 import (
 	pplnv1beta1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
-	corev1 "k8s.io/api/core/v1"
 )
 
-func taskFetchRepository() pplnv1beta1.PipelineTask {
+const (
+	taskNameFetchSources = "fetch-sources"
+	taskNameBuild        = "build"
+	taskNameDeploy       = "deploy"
+)
+
+func taskFetchSources() pplnv1beta1.PipelineTask {
 	return pplnv1beta1.PipelineTask{
-		Name: "fetch-repository",
+		Name: taskNameFetchSources,
 		TaskRef: &pplnv1beta1.TaskRef{
 			Name: "git-clone",
 		},
@@ -24,9 +29,9 @@ func taskFetchRepository() pplnv1beta1.PipelineTask {
 
 func taskBuild(runAfter string) pplnv1beta1.PipelineTask {
 	return pplnv1beta1.PipelineTask{
-		Name: "build",
+		Name: taskNameBuild,
 		TaskRef: &pplnv1beta1.TaskRef{
-			Name: "buildpacks",
+			Name: "func-buildpacks",
 		},
 		RunAfter: []string{runAfter},
 		Workspaces: []pplnv1beta1.WorkspacePipelineTaskBinding{
@@ -37,6 +42,10 @@ func taskBuild(runAfter string) pplnv1beta1.PipelineTask {
 			{
 				Name:      "cache",
 				Workspace: "cache-workspace",
+			},
+			{
+				Name:      "dockerconfig",
+				Workspace: "dockerconfig-workspace",
 			}},
 		Params: []pplnv1beta1.Param{
 			{Name: "APP_IMAGE", Value: *pplnv1beta1.NewArrayOrString("$(params.imageName)")},
@@ -46,61 +55,9 @@ func taskBuild(runAfter string) pplnv1beta1.PipelineTask {
 	}
 }
 
-// TODO this should be part of the future func-build Tekton Task as a post-build step
-func taskImageDigest(runAfter string) pplnv1beta1.PipelineTask {
-	script := `#!/usr/bin/env bash
-set -e
-
-func_file="/workspace/source/func.yaml"
-if [ "$(params.contextDir)" != "" ]; then
-  func_file="/workspace/source/$(params.contextDir)/func.yaml"
-fi
-
-sed -i "s|^image:.*$|image: $(params.image)|" "$func_file"
-echo "Function image name: $(params.image)"
-
-sed -i "s/^imageDigest:.*$/imageDigest: $(params.digest)/" "$func_file"
-echo "Function image digest: $(params.digest)"
-	`
-
+func taskDeploy(runAfter string) pplnv1beta1.PipelineTask {
 	return pplnv1beta1.PipelineTask{
-		Name: "image-digest",
-		TaskSpec: &pplnv1beta1.EmbeddedTask{
-			TaskSpec: pplnv1beta1.TaskSpec{
-				Workspaces: []pplnv1beta1.WorkspaceDeclaration{
-					{Name: "source"},
-				},
-				Steps: []pplnv1beta1.Step{
-					{
-						Container: corev1.Container{
-							Image: "docker.io/library/bash:5.1.4@sha256:b208215a4655538be652b2769d82e576bc4d0a2bb132144c060efc5be8c3f5d6",
-						},
-						Script: script,
-					},
-				},
-				Params: []pplnv1beta1.ParamSpec{
-					{Name: "image"},
-					{Name: "digest"},
-					{Name: "contextDir"},
-				},
-			},
-		},
-		RunAfter: []string{runAfter},
-		Workspaces: []pplnv1beta1.WorkspacePipelineTaskBinding{{
-			Name:      "source",
-			Workspace: "source-workspace",
-		}},
-		Params: []pplnv1beta1.Param{
-			{Name: "image", Value: *pplnv1beta1.NewArrayOrString("$(params.imageName)")},
-			{Name: "digest", Value: *pplnv1beta1.NewArrayOrString("$(tasks.build.results.APP_IMAGE_DIGEST)")},
-			{Name: "contextDir", Value: *pplnv1beta1.NewArrayOrString("$(params.contextDir)")},
-		},
-	}
-}
-
-func taskFuncDeploy(runAfter string) pplnv1beta1.PipelineTask {
-	return pplnv1beta1.PipelineTask{
-		Name: "deploy",
+		Name: taskNameDeploy,
 		TaskRef: &pplnv1beta1.TaskRef{
 			Name: "func-deploy",
 		},


### PR DESCRIPTION
Signed-off-by: Zbynek Roubalik <zroubalik@gmail.com>

<!-- Thanks for sending a pull request! -->

# Changes

<!-- 
Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! 

- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

- 🎁 on cluster build doesn't require privileged cluster permissions
- 🎁 uses custom version of `buildpacks` Tekton task -> there is added section in `results` step, that stores produced image name and sha to `func.yaml`.

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #848

