### PR TITLE
Use "openshift" uname for OpenShift image registry

### DIFF
--- a/openshift/openshift.go
+++ b/openshift/openshift.go
@@ -125,15 +125,8 @@ func GetDockerCredentialLoaders() []creds.CredentialsCallback {
 	}
 	authInfo := rawConf.AuthInfos[cc.AuthInfo]
 
-	var user string
-	parts := strings.SplitN(cc.AuthInfo, "/", 2)
-	if len(parts) >= 1 {
-		user = parts[0]
-	} else {
-		return nil
-	}
 	credentials := docker.Credentials{
-		Username: user,
+		Username: "openshift",
 		Password: authInfo.Token,
 	}
 


### PR DESCRIPTION
The user name from the config is invalid sometimes.
We can use `openshift` user name with user's token (it could be almost any other non-empty uname without colons in it).


```release-note
Fix issues with pushing to OpenShift's integrated registry when uname `kube:admin`
```

