### PR TITLE
Print logs if Pipeline Run fails

### DIFF
--- a/k8s/logs.go
+++ b/k8s/logs.go
@@ -1,0 +1,35 @@
+package k8s
+
+import (
+	"bytes"
+	"context"
+	"io"
+
+	corev1 "k8s.io/api/core/v1"
+)
+
+// GetPodLogs returns logs from a specified Container in a Pod, if container is empty string,
+// then the first container in the pod is selected.
+func GetPodLogs(ctx context.Context, namespace, podName, containerName string) (string, error) {
+	podLogOpts := corev1.PodLogOptions{}
+	if containerName != "" {
+		podLogOpts.Container = containerName
+	}
+
+	client, namespace, _ := NewClientAndResolvedNamespace(namespace)
+	request := client.CoreV1().Pods(namespace).GetLogs(podName, &podLogOpts)
+
+	containerLogStream, err := request.Stream(ctx)
+	if err != nil {
+		return "", err
+	}
+	defer containerLogStream.Close()
+
+	buffer := new(bytes.Buffer)
+	_, err = io.Copy(buffer, containerLogStream)
+	if err != nil {
+		return "", err
+	}
+
+	return buffer.String(), nil
+}


### PR DESCRIPTION
Signed-off-by: Zbynek Roubalik <zroubalik@gmail.com>

<!-- Thanks for sending a pull request! -->

# Changes

Return log message for a failed PipelineRun, returns log from a container where the failing TaskRun is running, if available.
eg:
```
./func deploy -p test-function
🕛 Creating Pipeline resources
🕒 Running Pipeline: Fetching git repository with the function source code
Error: failed to run pipeline: function pipeline run has failed with message: 

+ '[' false '=' true ]
+ '[' false '=' true ]
+ CHECKOUT_DIR=/workspace/output/
+ '[' true '=' true ]
+ cleandir
+ '[' -d /workspace/output/ ]
+ rm -rf '/workspace/output//*'
+ rm -rf '/workspace/output//.[!.]*'
+ rm -rf '/workspace/output//..?*'
+ test -z 
+ test -z 
+ test -z 
+ /ko-app/git-init '-url=https://github.com/zroubalik/testx-function.git' '-revision=' '-refspec=' '-path=/workspace/output/' '-sslVerify=true' '-submodules=true' '-depth=1' '-sparseCheckoutDirectories='
{"level":"error","ts":1649164840.929393,"caller":"git/git.go:54","msg":"Error running git [fetch --recurse-submodules=yes --depth=1 origin --update-head-ok --force HEAD]: exit status 128\nfatal: could not read Username for 'https://github.com': No such device or address\n","stacktrace":"github.com/tektoncd/pipeline/pkg/git.run\n\tgithub.com/tektoncd/pipeline/pkg/git/git.go:54\ngithub.com/tektoncd/pipeline/pkg/git.Fetch\n\tgithub.com/tektoncd/pipeline/pkg/git/git.go:149\nmain.main\n\tgithub.com/tektoncd/pipeline/cmd/git-init/main.go:53\nruntime.main\n\truntime/proc.go:204"}
{"level":"fatal","ts":1649164840.9294577,"caller":"git-init/main.go:54","msg":"Error fetching git repository: failed to fetch [HEAD]: exit status 128","stacktrace":"main.main\n\tgithub.com/tektoncd/pipeline/cmd/git-init/main.go:54\nruntime.main\n\truntime/proc.go:204"}
```

<!-- 
Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! 

- :gift: Print logs if Pipeline Run fails
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

- :gift: Print logs if Pipeline Run fails

Fixes #855