### PR TITLE
feat: invoke verbose metadata

### DIFF
--- a/client.go
+++ b/client.go
@@ -836,7 +836,8 @@ func (c *Client) Remove(ctx context.Context, cfg Function, deleteAll bool) error
 }
 
 // Invoke is a convenience method for triggering the execution of a Function
-// for testing and development.
+// for testing and development.  Returned is a map of metadata and a stringified
+// version of the content.
 // The target argument is optional, naming the running instance of the Function
 // which should be invoked.  This can be the literal names "local" or "remote",
 // or can be a URL to an arbitrary endpoint.  If not provided, a running local
@@ -848,7 +849,7 @@ func (c *Client) Remove(ctx context.Context, cfg Function, deleteAll bool) error
 // See NewInvokeMessage for its defaults.
 // Functions are invoked in a manner consistent with the settings defined in
 // their metadata.  For example HTTP vs CloudEvent
-func (c *Client) Invoke(ctx context.Context, root string, target string, m InvokeMessage) (s string, err error) {
+func (c *Client) Invoke(ctx context.Context, root string, target string, m InvokeMessage) (metadata map[string][]string, body string, err error) {
 	go func() {
 		<-ctx.Done()
 		c.progressListener.Stopping()

--- a/client_test.go
+++ b/client_test.go
@@ -1242,14 +1242,9 @@ func TestClient_Invoke_CloudEvent(t *testing.T) {
 	defer job.Stop()
 
 	// Invoke the Function, which will use the mock Runner
-	h, r, err := client.Invoke(context.Background(), f.Root, "", message)
+	_, r, err := client.Invoke(context.Background(), f.Root, "", message)
 	if err != nil {
 		t.Fatal(err)
-	}
-
-	// Assert metadata was returned by spot-checking id
-	if _, ok := h["id"]; !ok {
-		t.Fatal("expected metadata not returned")
 	}
 
 	// Test the contents of the returned string.

--- a/client_test.go
+++ b/client_test.go
@@ -1143,9 +1143,14 @@ func TestClient_Invoke_HTTP(t *testing.T) {
 	defer job.Stop()
 
 	// Invoke the Function, which will use the mock Runner
-	r, err := client.Invoke(context.Background(), f.Root, "", message)
+	h, r, err := client.Invoke(context.Background(), f.Root, "", message)
 	if err != nil {
 		t.Fatal(err)
+	}
+
+	// Assert the response includes headers by spot-checking Content-Type
+	if _, ok := h["Content-Type"]; !ok {
+		t.Fatal("expected headers not returned")
 	}
 
 	// Check the response value
@@ -1237,10 +1242,16 @@ func TestClient_Invoke_CloudEvent(t *testing.T) {
 	defer job.Stop()
 
 	// Invoke the Function, which will use the mock Runner
-	r, err := client.Invoke(context.Background(), f.Root, "", message)
+	h, r, err := client.Invoke(context.Background(), f.Root, "", message)
 	if err != nil {
 		t.Fatal(err)
 	}
+
+	// Assert metadata was returned by spot-checking id
+	if _, ok := h["id"]; !ok {
+		t.Fatal("expected metadata not returned")
+	}
+
 	// Test the contents of the returned string.
 	if r != evt.String() {
 		t.Fatal("Invoke failed to return a response")

--- a/cmd/invoke.go
+++ b/cmd/invoke.go
@@ -162,12 +162,12 @@ func runInvoke(cmd *cobra.Command, args []string, newClient ClientFactory) (err 
 		return err
 	}
 
-	// Print metadata (headers for HTTP, event fields for CloudEvents) if in
-	// verbose mode.
+	// Print metadata (headers for HTTP, CloudEvents include metadat in their
+	// default stringification) if in
 	if cfg.Verbose {
 		for k, vv := range metadata {
 			values := strings.Join(vv, ";")
-			fmt.Fprintf(cmd.OutOrStdout(), "\"%v\":%v\n", k, values)
+			fmt.Fprintf(cmd.OutOrStdout(), "%v: %v\n", k, values)
 		}
 		if len(metadata) > 0 {
 			fmt.Fprintln(cmd.OutOrStdout())

--- a/cmd/invoke.go
+++ b/cmd/invoke.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
+	"strings"
 
 	"github.com/AlecAivazis/survey/v2"
 	"github.com/google/uuid"
@@ -156,12 +157,24 @@ func runInvoke(cmd *cobra.Command, args []string, newClient ClientFactory) (err 
 	}
 
 	// Invoke
-	s, err := client.Invoke(cmd.Context(), cfg.Path, cfg.Target, m)
+	metadata, body, err := client.Invoke(cmd.Context(), cfg.Path, cfg.Target, m)
 	if err != nil {
 		return err
 	}
 
-	fmt.Fprintln(cmd.OutOrStderr(), s)
+	// Print metadata (headers for HTTP, event fields for CloudEvents) if in
+	// verbose mode.
+	if cfg.Verbose {
+		for k, vv := range metadata {
+			values := strings.Join(vv, ";")
+			fmt.Fprintf(cmd.OutOrStdout(), "\"%v\":%v\n", k, values)
+		}
+		if len(metadata) > 0 {
+			fmt.Fprintln(cmd.OutOrStdout())
+		}
+	}
+
+	fmt.Fprintln(cmd.OutOrStdout(), body)
 	return
 }
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

# Changes

- :gift: `invoke -v` prints metadata

HTTP headers or CloudEvent fields are printed on invoke with verbose enabled.

```shell
$ func invoke --verbose
"Content-Type":text/plain; charset=utf-8
"Date":Tue, 05 Apr 2022 14:02:10 GMT
"Content-Length":3

OK
```

/kind enhancement

Fixes #922 