### PR TITLE
Refactor: templates

### DIFF
--- a/client.go
+++ b/client.go
@@ -546,7 +546,7 @@ func (c *Client) Create(cfg Function) (err error) {
 	// Templates contain values which may result in the Function being mutated
 	// (default builders, etc), so a new (potentially mutated) Function is
 	// returned from Templates.Write
-	f, err = c.Templates().Write(f)
+	err = c.Templates().Write(&f)
 	if err != nil {
 		return
 	}

--- a/filesystem.go
+++ b/filesystem.go
@@ -8,7 +8,6 @@ import (
 	"os"
 	"path"
 	"path/filepath"
-	"sort"
 	"strings"
 
 	billy "github.com/go-git/go-billy/v5"
@@ -148,67 +147,50 @@ func (o osFilesystem) Stat(name string) (fs.FileInfo, error) {
 // copy
 
 func copy(src, dest string, accessor Filesystem) (err error) {
-	node, err := accessor.Stat(src)
-	if err != nil {
-		return
-	}
-	if node.IsDir() {
-		return copyNode(src, dest, accessor)
-	} else {
-		return copyLeaf(src, dest, accessor)
-	}
-}
 
-func copyNode(src, dest string, accessor Filesystem) (err error) {
-	// Ideally we should use the file mode of the src node
-	// but it seems the git module is reporting directories
-	// as 0644 instead of 0755. For now, just do it this way.
-	// See https://github.com/go-git/go-git/issues/364
-	// Upon resolution, return accessor.Stat(src).Mode()
-	err = os.MkdirAll(dest, 0755)
-	if err != nil {
-		return
-	}
-
-	children, err := readDir(src, accessor)
-	if err != nil {
-		return
-	}
-	for _, child := range children {
-		if err = copy(path.Join(src, child.Name()), filepath.Join(dest, child.Name()), accessor); err != nil {
-			return
+	return fs.WalkDir(accessor, src, func(path string, de fs.DirEntry, err error) error {
+		if err != nil {
+			return err
 		}
-	}
-	return
-}
 
-func readDir(src string, accessor Filesystem) ([]fs.DirEntry, error) {
-	list, err := accessor.ReadDir(src)
-	if err != nil {
-		return nil, err
-	}
-	sort.Slice(list, func(i, j int) bool { return list[i].Name() < list[j].Name() })
-	return list, nil
-}
+		if path == src {
+			return nil
+		}
 
-func copyLeaf(src, dest string, accessor Filesystem) (err error) {
-	srcFile, err := accessor.Open(src)
-	if err != nil {
-		return
-	}
-	defer srcFile.Close()
+		p, err := filepath.Rel(filepath.FromSlash(src), filepath.FromSlash(path))
+		if err != nil {
+			return err
+		}
 
-	srcFileInfo, err := accessor.Stat(src)
-	if err != nil {
-		return
-	}
+		dest := filepath.Join(dest, p)
+		if de.IsDir() {
+			// Ideally we should use the file mode of the src node
+			// but it seems the git module is reporting directories
+			// as 0644 instead of 0755. For now, just do it this way.
+			// See https://github.com/go-git/go-git/issues/364
+			// Upon resolution, return accessor.Stat(src).Mode()
+			return os.MkdirAll(dest, 0755)
+		} else {
+			fi, err := de.Info()
+			if err != nil {
+				return err
+			}
 
-	destFile, err := os.OpenFile(dest, os.O_RDWR|os.O_CREATE|os.O_TRUNC, srcFileInfo.Mode())
-	if err != nil {
-		return
-	}
-	defer destFile.Close()
+			destFile, err := os.OpenFile(dest, os.O_RDWR|os.O_CREATE|os.O_TRUNC, fi.Mode())
+			if err != nil {
+				return err
+			}
+			defer destFile.Close()
 
-	_, err = io.Copy(destFile, srcFile)
-	return
+			srcFile, err := accessor.Open(path)
+			if err != nil {
+				return err
+			}
+			defer srcFile.Close()
+
+			_, err = io.Copy(destFile, srcFile)
+			return err
+		}
+	})
+
 }

--- a/filesystem.go
+++ b/filesystem.go
@@ -144,9 +144,10 @@ func (o osFilesystem) Stat(name string) (fs.FileInfo, error) {
 	return os.Stat(filepath.Join(o.root, name))
 }
 
-// copy
-
-func copy(src, dest string, accessor Filesystem) (err error) {
+// copyFromFS copies files from the `src` dir on the accessor Filesystem to local filesystem into `dest` dir.
+// The src path uses slashes as their separator.
+// The dest path uses OS specific separator.
+func copyFromFS(src, dest string, accessor Filesystem) (err error) {
 
 	return fs.WalkDir(accessor, src, func(path string, de fs.DirEntry, err error) error {
 		if err != nil {

--- a/filesystem.go
+++ b/filesystem.go
@@ -144,6 +144,24 @@ func (o osFilesystem) Stat(name string) (fs.FileInfo, error) {
 	return os.Stat(filepath.Join(o.root, name))
 }
 
+// subFS exposes subdirectory of underlying FS, this is similar to `chroot`.
+type subFS struct {
+	root string
+	fs   Filesystem
+}
+
+func (o subFS) Open(name string) (fs.File, error) {
+	return o.fs.Open(path.Join(o.root, name))
+}
+
+func (o subFS) ReadDir(name string) ([]fs.DirEntry, error) {
+	return o.fs.ReadDir(path.Join(o.root, name))
+}
+
+func (o subFS) Stat(name string) (fs.FileInfo, error) {
+	return o.fs.Stat(path.Join(o.root, name))
+}
+
 // copyFromFS copies files from the `src` dir on the accessor Filesystem to local filesystem into `dest` dir.
 // The src path uses slashes as their separator.
 // The dest path uses OS specific separator.

--- a/filesystem.go
+++ b/filesystem.go
@@ -225,27 +225,26 @@ func copyFromFS(src, dest string, accessor Filesystem) (err error) {
 			// See https://github.com/go-git/go-git/issues/364
 			// Upon resolution, return accessor.Stat(src).Mode()
 			return os.MkdirAll(dest, 0755)
-		} else {
-			fi, err := de.Info()
-			if err != nil {
-				return err
-			}
-
-			destFile, err := os.OpenFile(dest, os.O_RDWR|os.O_CREATE|os.O_TRUNC, fi.Mode())
-			if err != nil {
-				return err
-			}
-			defer destFile.Close()
-
-			srcFile, err := accessor.Open(path)
-			if err != nil {
-				return err
-			}
-			defer srcFile.Close()
-
-			_, err = io.Copy(destFile, srcFile)
+		}
+		fi, err := de.Info()
+		if err != nil {
 			return err
 		}
+
+		destFile, err := os.OpenFile(dest, os.O_RDWR|os.O_CREATE|os.O_TRUNC, fi.Mode())
+		if err != nil {
+			return err
+		}
+		defer destFile.Close()
+
+		srcFile, err := accessor.Open(path)
+		if err != nil {
+			return err
+		}
+		defer srcFile.Close()
+
+		_, err = io.Copy(destFile, srcFile)
+		return err
 	})
 
 }

--- a/repository.go
+++ b/repository.go
@@ -482,7 +482,7 @@ func (r *Repository) Write(path string) (err error) {
 		}
 		fs = billyFilesystem{fs: wt.Filesystem}
 	}
-	return copy(".", path, fs)
+	return copyFromFS(".", path, fs)
 }
 
 // URL attempts to read the remote git origin URL of the repository.  Best

--- a/repository.go
+++ b/repository.go
@@ -244,7 +244,7 @@ func repositoryRuntimes(r Repository) (runtimes []Runtime, err error) {
 
 	// Load runtimes
 	if r.TemplatesPath == "" {
-		r.TemplatesPath = "."
+		r.TemplatesPath = DefaultTemplatesPath
 	}
 
 	fis, err := r.FS.ReadDir(r.TemplatesPath)
@@ -292,7 +292,7 @@ func runtimeTemplates(r Repository, runtime Runtime) (templates []Template, err 
 
 	tp := r.TemplatesPath
 	if tp == "" {
-		tp = "."
+		tp = DefaultTemplatesPath
 	}
 
 	// Validate runtime directory exists and is a directory

--- a/repository.go
+++ b/repository.go
@@ -316,13 +316,7 @@ func runtimeTemplates(r Repository, runtime Runtime) (templates []Template, err 
 				BuildEnvs:       runtime.BuildEnvs,
 				Invocation:      runtime.Invocation,
 			},
-			fs: maskingFS{
-				fs: subFS{root: path.Join(runtimePath, fi.Name()), fs: r.FS},
-				masked: func(p string) bool {
-					_, f := path.Split(p)
-					return f == templateManifest
-				},
-			},
+			fs: subFS{root: path.Join(runtimePath, fi.Name()), fs: r.FS},
 		}
 
 		// Template Manifeset

--- a/repository.go
+++ b/repository.go
@@ -323,7 +323,13 @@ func runtimeTemplates(r Repository, runtime Runtime) (templates []Template, err 
 				BuildEnvs:       runtime.BuildEnvs,
 				Invocation:      runtime.Invocation,
 			},
-			fs: subFS{root: path.Join(runtimePath, fi.Name()), fs: r.FS},
+			fs: maskingFS{
+				fs: subFS{root: path.Join(runtimePath, fi.Name()), fs: r.FS},
+				masked: func(p string) bool {
+					_, f := path.Split(p)
+					return f == templateManifest
+				},
+			},
 		}
 
 		// Template Manifeset

--- a/repository_test.go
+++ b/repository_test.go
@@ -44,6 +44,9 @@ func TestRepository_Inheritance(t *testing.T) {
 	client := fn.New(fn.WithRepositoriesPath("testdata/repositories"))
 
 	repo, err := client.Repositories().Get("customLanguagePackRepo")
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	// Template A:  from a path containing no settings other than the repo root.
 	// Should have a readiness and liveness equivalent to that defined in

--- a/template.go
+++ b/template.go
@@ -1,20 +1,20 @@
 package function
 
-// Template
-type Template struct {
-	// Name (short name) of this template within the repository.
-	// See .Fullname for the calculated field which is the unique primary id.
-	Name string `yaml:"-"` // use filesystem for name, not yaml
+import (
+	"context"
+	"os"
+	"path/filepath"
+)
 
-	// Runtime for which this template applies.
-	Runtime string
+type Template interface {
+	Name() string
+	Runtime() string
+	Repository() string
+	Fullname() string
+	Write(ctx context.Context, f *Function) error
+}
 
-	// Repository within which this template is contained.  Value is set to the
-	// currently effective name of the repository, which may vary. It is user-
-	// defined when the repository is added, and can be set to "default" when
-	// the client is loaded in single repo mode. I.e. not canonical.
-	Repository string
-
+type templateConfig struct {
 	// BuildConfig defines builders and buildpacks.  the denormalized view of
 	// members which can be defined per repo or per runtime first.
 	BuildConfig `yaml:",inline"`
@@ -32,9 +32,84 @@ type Template struct {
 	Invocation Invocation `yaml:"invocation,omitempty"`
 }
 
+// template
+type template struct {
+	name string
+
+	// Runtime for which this template applies.
+	runtime string
+
+	// Repository within which this template is contained.  Value is set to the
+	// currently effective name of the repository, which may vary. It is user-
+	// defined when the repository is added, and can be set to "default" when
+	// the client is loaded in single repo mode. I.e. not canonical.
+	repository string
+
+	// filesystem containing template files
+	fs Filesystem
+
+	// manifest containing defaults for `fn.Function` struct
+	manifest templateConfig
+}
+
+func (t *template) Name() string {
+	return t.name
+}
+
+func (t *template) Runtime() string {
+	return t.runtime
+}
+
+func (t *template) Repository() string {
+	return t.repository
+}
+
 // Fullname is a calculated field of [repo]/[name] used
 // to uniquely reference a template which may share a name
 // with one in another repository.
-func (t Template) Fullname() string {
-	return t.Repository + "/" + t.Name
+func (t *template) Fullname() string {
+	return t.repository + "/" + t.name
+}
+
+func (t *template) Write(ctx context.Context, f *Function) error {
+
+	// Apply fields from the template onto the function itself (Denormalize).
+	// The template is already the denormalized view of repo->runtime->template
+	// so it's values are treated as defaults.
+	// TODO: this begs the question: should the Template's manifest.yaml actually
+	// be a partially-populated func.yaml?
+	if f.Builder == "" { // as a special first case, this default comes from itself
+		f.Builder = f.Builders["default"]
+		if f.Builder == "" { // still nothing?  then use the template
+			f.Builder = t.manifest.Builders["default"]
+		}
+	}
+	if len(f.Builders) == 0 {
+		f.Builders = t.manifest.Builders
+	}
+	if len(f.Buildpacks) == 0 {
+		f.Buildpacks = t.manifest.Buildpacks
+	}
+	if len(f.BuildEnvs) == 0 {
+		f.BuildEnvs = t.manifest.BuildEnvs
+	}
+	if f.HealthEndpoints.Liveness == "" {
+		f.HealthEndpoints.Liveness = t.manifest.HealthEndpoints.Liveness
+	}
+	if f.HealthEndpoints.Readiness == "" {
+		f.HealthEndpoints.Readiness = t.manifest.HealthEndpoints.Readiness
+	}
+	if f.Invocation.Format == "" {
+		f.Invocation.Format = t.manifest.Invocation.Format
+	}
+
+	// Copy the template files from the repo filesystem to the new Function's root
+	// removing the manifest (if it exists; errors ignored)
+	err := copyFromFS(".", f.Root, t.fs) // copy everything
+	if err != nil {
+		return err
+	}
+
+	_ = os.Remove(filepath.Join(f.Root, templateManifest)) // except the manifest
+	return nil
 }

--- a/template.go
+++ b/template.go
@@ -2,6 +2,7 @@ package function
 
 import (
 	"context"
+	"path"
 )
 
 type Template interface {
@@ -101,5 +102,10 @@ func (t template) Write(ctx context.Context, f *Function) error {
 		f.Invocation.Format = t.manifest.Invocation.Format
 	}
 
-	return copyFromFS(".", f.Root, t.fs) // copy everything
+	isManifest := func(p string) bool {
+		_, f := path.Split(p)
+		return f == templateManifest
+	}
+
+	return copyFromFS(".", f.Root, maskingFS{fs: t.fs, masked: isManifest}) // copy everything but manifest.yaml
 }

--- a/template.go
+++ b/template.go
@@ -50,26 +50,26 @@ type template struct {
 	manifest templateConfig
 }
 
-func (t *template) Name() string {
+func (t template) Name() string {
 	return t.name
 }
 
-func (t *template) Runtime() string {
+func (t template) Runtime() string {
 	return t.runtime
 }
 
-func (t *template) Repository() string {
+func (t template) Repository() string {
 	return t.repository
 }
 
 // Fullname is a calculated field of [repo]/[name] used
 // to uniquely reference a template which may share a name
 // with one in another repository.
-func (t *template) Fullname() string {
+func (t template) Fullname() string {
 	return t.repository + "/" + t.name
 }
 
-func (t *template) Write(ctx context.Context, f *Function) error {
+func (t template) Write(ctx context.Context, f *Function) error {
 
 	// Apply fields from the template onto the function itself (Denormalize).
 	// The template is already the denormalized view of repo->runtime->template

--- a/template.go
+++ b/template.go
@@ -6,10 +6,20 @@ import (
 )
 
 type Template interface {
+	// Name of this template.
 	Name() string
+	// Runtime for which this template applies.
 	Runtime() string
+	// Repository within which this template is contained.  Value is set to the
+	// currently effective name of the repository, which may vary. It is user-
+	// defined when the repository is added, and can be set to "default" when
+	// the client is loaded in single repo mode. I.e. not canonical.
 	Repository() string
+	// Fullname is a calculated field of [repo]/[name] used
+	// to uniquely reference a template which may share a name
+	// with one in another repository.
 	Fullname() string
+	// Write updates fields of Function f and writes project files to path pointed by f.Root.
 	Write(ctx context.Context, f *Function) error
 }
 
@@ -33,22 +43,11 @@ type templateConfig struct {
 
 // template
 type template struct {
-	name string
-
-	// Runtime for which this template applies.
-	runtime string
-
-	// Repository within which this template is contained.  Value is set to the
-	// currently effective name of the repository, which may vary. It is user-
-	// defined when the repository is added, and can be set to "default" when
-	// the client is loaded in single repo mode. I.e. not canonical.
+	name       string
+	runtime    string
 	repository string
-
-	// filesystem containing template files
-	fs Filesystem
-
-	// manifest containing defaults for `fn.Function` struct
-	manifest templateConfig
+	fs         Filesystem
+	manifest   templateConfig
 }
 
 func (t template) Name() string {
@@ -63,9 +62,6 @@ func (t template) Repository() string {
 	return t.repository
 }
 
-// Fullname is a calculated field of [repo]/[name] used
-// to uniquely reference a template which may share a name
-// with one in another repository.
 func (t template) Fullname() string {
 	return t.repository + "/" + t.name
 }

--- a/template.go
+++ b/template.go
@@ -2,8 +2,6 @@ package function
 
 import (
 	"context"
-	"os"
-	"path/filepath"
 )
 
 type Template interface {
@@ -103,13 +101,5 @@ func (t *template) Write(ctx context.Context, f *Function) error {
 		f.Invocation.Format = t.manifest.Invocation.Format
 	}
 
-	// Copy the template files from the repo filesystem to the new Function's root
-	// removing the manifest (if it exists; errors ignored)
-	err := copyFromFS(".", f.Root, t.fs) // copy everything
-	if err != nil {
-		return err
-	}
-
-	_ = os.Remove(filepath.Join(f.Root, templateManifest)) // except the manifest
-	return nil
+	return copyFromFS(".", f.Root, t.fs) // copy everything
 }

--- a/templates.go
+++ b/templates.go
@@ -163,7 +163,7 @@ func (t *Templates) Write(f Function) (Function, error) {
 
 	// Copy the template files from the repo filesystem to the new Function's root
 	// removing the manifest (if it exists; errors ignored)
-	err = copy(templatePath, f.Root, repo.FS)              // copy everything
+	err = copyFromFS(templatePath, f.Root, repo.FS)        // copy everything
 	_ = os.Remove(filepath.Join(f.Root, templateManifest)) // except the manifest
 
 	return f, err

--- a/templates.go
+++ b/templates.go
@@ -1,10 +1,8 @@
 package function
 
 import (
+	"context"
 	"errors"
-	"os"
-	"path"
-	"path/filepath"
 	"strings"
 )
 
@@ -49,7 +47,7 @@ func (t *Templates) List(runtime string) ([]string, error) {
 		}
 		for _, t := range tt {
 			if r.Name == DefaultRepositoryName {
-				names = append(names, t.Name)
+				names = append(names, t.Name())
 			} else {
 				extended.Add(t.Fullname())
 			}
@@ -95,76 +93,18 @@ func (t *Templates) Get(runtime, fullname string) (Template, error) {
 // Returns a Function which may have been modified dependent on the content
 // of the template (which can define default Function fields, builders,
 // buildpacks, etc)
-func (t *Templates) Write(f Function) (Function, error) {
+func (t *Templates) Write(f *Function) error {
 	// Templates require an initially valid Function to write
 	// (has name, path, runtime etc)
 	if err := f.Validate(); err != nil {
-		return f, err
+		return err
 	}
 
 	// The Function's Template
 	template, err := t.Get(f.Runtime, f.Template)
 	if err != nil {
-		return f, err
+		return err
 	}
 
-	// The Function's Template Repository
-	repo, err := t.client.Repositories().Get(template.Repository)
-	if err != nil {
-		return f, err
-	}
-
-	// Validate paths:  (repo/)[templates/]<runtime>/<template>
-	templatesPath := repo.TemplatesPath
-	if templatesPath == "" {
-		templatesPath = "."
-	}
-	if _, err := repo.FS.Stat(templatesPath); err != nil {
-		return f, ErrTemplatesNotFound
-	}
-	runtimePath := path.Join(templatesPath, template.Runtime)
-	if _, err := repo.FS.Stat(runtimePath); err != nil {
-		return f, ErrRuntimeNotFound
-	}
-	templatePath := path.Join(runtimePath, template.Name)
-	if _, err := repo.FS.Stat(templatePath); err != nil {
-		return f, ErrTemplateNotFound
-	}
-
-	// Apply fields from the template onto the function itself (Denormalize).
-	// The template is already the denormalized view of repo->runtime->template
-	// so it's values are treated as defaults.
-	// TODO: this begs the question: should the Template's manifest.yaml actually
-	// be a partially-populated func.yaml?
-	if f.Builder == "" { // as a special first case, this default comes from itself
-		f.Builder = f.Builders["default"]
-		if f.Builder == "" { // still nothing?  then use the template
-			f.Builder = template.Builders["default"]
-		}
-	}
-	if len(f.Builders) == 0 {
-		f.Builders = template.Builders
-	}
-	if len(f.Buildpacks) == 0 {
-		f.Buildpacks = template.Buildpacks
-	}
-	if len(f.BuildEnvs) == 0 {
-		f.BuildEnvs = template.BuildEnvs
-	}
-	if f.HealthEndpoints.Liveness == "" {
-		f.HealthEndpoints.Liveness = template.HealthEndpoints.Liveness
-	}
-	if f.HealthEndpoints.Readiness == "" {
-		f.HealthEndpoints.Readiness = template.HealthEndpoints.Readiness
-	}
-	if f.Invocation.Format == "" {
-		f.Invocation.Format = template.Invocation.Format
-	}
-
-	// Copy the template files from the repo filesystem to the new Function's root
-	// removing the manifest (if it exists; errors ignored)
-	err = copyFromFS(templatePath, f.Root, repo.FS)        // copy everything
-	_ = os.Remove(filepath.Join(f.Root, templateManifest)) // except the manifest
-
-	return f, err
+	return template.Write(context.TODO(), f)
 }

--- a/templates_test.go
+++ b/templates_test.go
@@ -78,9 +78,9 @@ func TestTemplates_Get(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if embedded.Runtime != "go" || embedded.Repository != "default" || embedded.Name != "http" {
+	if embedded.Runtime() != "go" || embedded.Repository() != "default" || embedded.Name() != "http" {
 		t.Logf("Expected template from embedded to have runtime 'go' repo 'default' name 'http', got '%v', '%v', '%v',",
-			embedded.Runtime, embedded.Repository, embedded.Name)
+			embedded.Runtime(), embedded.Repository(), embedded.Name())
 	}
 
 	// Check extended
@@ -89,9 +89,9 @@ func TestTemplates_Get(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if embedded.Runtime != "go" || embedded.Repository != "default" || embedded.Name != "http" {
+	if embedded.Runtime() != "go" || embedded.Repository() != "default" || embedded.Name() != "http" {
 		t.Logf("Expected template from extended repo to have runtime 'go' repo 'customTemplateRepo' name 'customTemplate', got '%v', '%v', '%v',",
-			extended.Runtime, extended.Repository, extended.Name)
+			extended.Runtime(), extended.Repository(), extended.Name())
 	}
 }
 


### PR DESCRIPTION
Make `fn.Template` an interface instead of a concrete struct.