### PR TITLE
chore: add version.txt to .gitattributes for style

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,3 @@
 testdata/repository-a.git/objects/*/* ignore-lint=true
 testdata/repository.git/objects/*/* ignore-lint=true
-
+version.txt linguist-generated=true

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,4 @@
 testdata/repository-a.git/objects/*/* ignore-lint=true
 testdata/repository.git/objects/*/* ignore-lint=true
 version.txt linguist-generated=true
+zz_filesystem_generated.go linguist-generated=true


### PR DESCRIPTION
🧹  The Knative style check uses linguist to determine if a given file is a generated file. If so, it excludes that file from the check. This change should prevent Knative's style check from complaining about no newline on version.txt

Signed-off-by: Lance Ball <lball@redhat.com>

/kind chore
