### PR TITLE
Add unicode control chars exclude

### DIFF
--- a/.unicode-control-characters.config.py
+++ b/.unicode-control-characters.config.py
@@ -1,0 +1,3 @@
+scan_exclude = [
+    # Readme in vendor dir line=17,title=unicode control characters ['\u200d'] 
+    r'./vendor/github.com/rivo/uniseg/README.md']

--- a/.unicode-control-characters.config.py
+++ b/.unicode-control-characters.config.py
@@ -1,3 +1,3 @@
 scan_exclude = [
     # Readme in vendor dir line=17,title=unicode control characters ['\u200d'] 
-    r'./vendor/github.com/rivo/uniseg/README.md']
+    r'vendor/github\.com/rivo/uniseg/README\.md']

--- a/.unicode-control-characters.config.py
+++ b/.unicode-control-characters.config.py
@@ -1,3 +1,3 @@
 scan_exclude = [
-    # Readme in vendor dir line=17,title=unicode control characters ['\u200d'] 
+    # Readme in vendor dir line=17,title=unicode control characters ['\u200d']
     r'vendor/github\.com/rivo/uniseg/README\.md']


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

With recent update to security action. The following file should be used to exclude false positive reports.

# Changes

- :bug: Add unicode control chars exclude

PTAL
/cc @pierDipi @cardil 

