### PR TITLE
Refactor: clean Repository and Runtimes structs

### DIFF
--- a/function.go
+++ b/function.go
@@ -106,6 +106,18 @@ type Function struct {
 	Invocation Invocation `yaml:"invocation,omitempty"`
 }
 
+// HealthEndpoints specify the liveness and readiness endpoints for a Runtime
+type HealthEndpoints struct {
+	Liveness  string `yaml:"liveness,omitempty"`
+	Readiness string `yaml:"readiness,omitempty"`
+}
+
+// BuildConfig defines builders and buildpacks
+type BuildConfig struct {
+	Buildpacks []string          `yaml:"buildpacks,omitempty"`
+	Builders   map[string]string `yaml:"builders,omitempty"`
+}
+
 // Invocation defines hints on how to accomplish a Function invocation.
 type Invocation struct {
 	// Format indicates the expected format of the invocation.  Either 'http'

--- a/repository.go
+++ b/repository.go
@@ -310,11 +310,11 @@ func runtimeTemplates(fs Filesystem, templatesPath, repoName, runtimeName string
 		}
 		// Template, defaulted to values inherited from the runtime
 		t := template{
-			name:        fi.Name(),
-			repository:  repoName,
-			runtime:     runtimeName,
-			templConfig: runtimeConfig,
-			fs:          subFS{root: path.Join(runtimePath, fi.Name()), fs: fs},
+			name:       fi.Name(),
+			repository: repoName,
+			runtime:    runtimeName,
+			config:     runtimeConfig,
+			fs:         subFS{root: path.Join(runtimePath, fi.Name()), fs: fs},
 		}
 
 		// Template Manifeset
@@ -398,7 +398,7 @@ func applyTemplateManifest(fs Filesystem, templatesPath string, t template) (tem
 		return t, err
 	}
 	decoder := yaml.NewDecoder(file)
-	return t, decoder.Decode(&t.templConfig)
+	return t, decoder.Decode(&t.config)
 }
 
 // check that the given path is an accessible directory or error.

--- a/template.go
+++ b/template.go
@@ -7,11 +7,11 @@ import (
 
 // template
 type template struct {
-	name        string
-	runtime     string
-	repository  string
-	fs          Filesystem
-	templConfig templateConfig
+	name       string
+	runtime    string
+	repository string
+	fs         Filesystem
+	config     templateConfig
 }
 
 func (t template) Name() string {
@@ -40,26 +40,26 @@ func (t template) Write(ctx context.Context, f *Function) error {
 	if f.Builder == "" { // as a special first case, this default comes from itself
 		f.Builder = f.Builders["default"]
 		if f.Builder == "" { // still nothing?  then use the template
-			f.Builder = t.templConfig.Builders["default"]
+			f.Builder = t.config.Builders["default"]
 		}
 	}
 	if len(f.Builders) == 0 {
-		f.Builders = t.templConfig.Builders
+		f.Builders = t.config.Builders
 	}
 	if len(f.Buildpacks) == 0 {
-		f.Buildpacks = t.templConfig.Buildpacks
+		f.Buildpacks = t.config.Buildpacks
 	}
 	if len(f.BuildEnvs) == 0 {
-		f.BuildEnvs = t.templConfig.BuildEnvs
+		f.BuildEnvs = t.config.BuildEnvs
 	}
 	if f.HealthEndpoints.Liveness == "" {
-		f.HealthEndpoints.Liveness = t.templConfig.HealthEndpoints.Liveness
+		f.HealthEndpoints.Liveness = t.config.HealthEndpoints.Liveness
 	}
 	if f.HealthEndpoints.Readiness == "" {
-		f.HealthEndpoints.Readiness = t.templConfig.HealthEndpoints.Readiness
+		f.HealthEndpoints.Readiness = t.config.HealthEndpoints.Readiness
 	}
 	if f.Invocation.Format == "" {
-		f.Invocation.Format = t.templConfig.Invocation.Format
+		f.Invocation.Format = t.config.Invocation.Format
 	}
 
 	isManifest := func(p string) bool {


### PR DESCRIPTION
* moved `HealthEndpoints` and `BuildConfig` structs to `function.go`
* moved `Template` to `repository.go` so `Repository`, `Runtime` and `Template` are together.
* removed fields that were leaking details from `Repository` and `Runtime`