### PR TITLE
[fix] Docs typo: "Knaive" -> "Knative"

### DIFF
--- a/docs/function-developers/developers_guide.md
+++ b/docs/function-developers/developers_guide.md
@@ -1,5 +1,5 @@
 # Function Developer's Guide
-Here you will find links to getting started guides, reference documents and other information important to know as a Knaive Function developer.
+Here you will find links to getting started guides, reference documents and other information important to know as a Knative Function developer.
 
 ## Prerequisites and Installation
 Before learning to develop Functions, you should have the client [installed](../installing_cli.md) and a configured [Kubernetes cluster](../getting_started_kubernetes.md) with Knative installed.


### PR DESCRIPTION
Signed-off-by: Bryan Tong <tongb@vmware.com>

<!-- Thanks for sending a pull request! -->

# Changes

<!-- 
Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! 

- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

- Fix typo of "Knaive" -> "Knative>

<!--
In addition, categorize the changes you're making using the "/kind" Prow command, example:

/kind bug

Supported kinds are: api-change, bug, cleanup, deprecation, removal, documentation, enhancement, performance

-->
/kind documentation

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
No issue exists since it's a small typo

<!-- Please include the 'why' behind your changes if no issue exists -->

**Release Note**
Fix typo in developer's docs

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->
```release-note
Fix typo in documentation
```

**Docs**

<!--
:book: If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [knative/docs]: <issue or pr link>
- [Feature Track]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
