### PR TITLE
fix: ignore `is forbidden` errors when deleting function and resources

### DIFF
--- a/pipelines/tekton/pipeplines_provider.go
+++ b/pipelines/tekton/pipeplines_provider.go
@@ -186,7 +186,7 @@ func (pp *PipelinesProvider) Remove(ctx context.Context, f fn.Function) error {
 		go func() {
 			defer wg.Done()
 			err := df(ctx, pp.namespace, listOptions)
-			if err != nil && !errors.IsNotFound(err) {
+			if err != nil && !errors.IsNotFound(err) && !errors.IsForbidden(err) {
 				errChan <- err
 			}
 		}()


### PR DESCRIPTION
Signed-off-by: Zbynek Roubalik <zroubalik@gmail.com>

<!-- Thanks for sending a pull request! -->

Fixes: #986 
