### PR TITLE
feat: s2i builder env var interpolation

### DIFF
--- a/function.go
+++ b/function.go
@@ -234,13 +234,13 @@ var envPattern = regexp.MustCompile(`^{{\s*(\w+)\s*:(\w+)\s*}}$`)
 func Interpolate(ee []Env) (map[string]string, error) {
 	envs := make(map[string]string, len(ee))
 	for _, e := range ee {
-		// Assert non-nil and dereference.
-		// See comment in assocaited test re: using pointers at all.
+		// Assert non-nil name.
 		if e.Name == nil {
 			return envs, errors.New("env name may not be nil")
 		}
+		// Nil value indicates the resultant map should not include this env var.
 		if e.Value == nil {
-			return envs, errors.New("env value may not be nil")
+			continue
 		}
 		k, v := *e.Name, *e.Value
 

--- a/function_test.go
+++ b/function_test.go
@@ -85,6 +85,9 @@ func TestFunction_NameDefault(t *testing.T) {
 // Test_Interpolate ensures environment variable interpolation processes
 // environment variables by interpolating properly formatted references to
 // local environment variables, returning a final simple map structure.
+// Also ensures that nil value references are interpreted as meaning the
+// environment is to be disincluded from the resultant map, rathern than included
+// with an empty value.
 // TODO: Perhaps referring to a nonexistent local env var should be treated
 // as a "leave as is" (do not set) rather than "required" resulting in error?
 // TODO: What use case does a nil pointer in the Env struct serve?  Add it
@@ -120,5 +123,15 @@ func Test_Interpolate(t *testing.T) {
 		if v != c.Expected {
 			t.Fatalf("expected env value '%v' to be interpolated as '%v', but got '%v'", c.Value, c.Expected, v)
 		}
+	}
+
+	// Nil value should be treated as being disincluded from the resultant map.
+	envs := []fn.Env{{Name: &name}} // has a nil *Value ptr
+	vv, err := fn.Interpolate(envs)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(vv) != 0 {
+		t.Fatalf("expected envs with a nil value to not be included in interpolation result")
 	}
 }


### PR DESCRIPTION
- :gift: S2I Builder Env Interpolation

More specifically:

* Extracts env var interpolation logic from buildpack builder to shared package static `fn.Interpolate`
* Refactors implementation slightly to pass-through unmatched values (previously a bit ambiguous, presuming permissive).
* Adds interpolation tests, including explicit tests for asserting both unmatched strings pass through and nil value pointers indicate env var should be omitted from the final interpolated map.
* Integrates interpolated build envs into S2I builder.

/kind enhancement

Fixes #990 