### PR TITLE
Fix read pwd from non-tty input

### DIFF
--- a/cmd/client.go
+++ b/cmd/client.go
@@ -119,7 +119,7 @@ func newTransport() fnhttp.RoundTripCloser {
 // of features or configuration nuances of cluster variants.
 func newCredentialsProvider(t http.RoundTripper) docker.CredentialsProvider {
 	options := []creds.Opt{
-		creds.WithPromptForCredentials(newPromptForCredentials()),
+		creds.WithPromptForCredentials(newPromptForCredentials(os.Stdin, os.Stdout, os.Stderr)),
 		creds.WithPromptForCredentialStore(newPromptForCredentialStore()),
 		creds.WithTransport(t),
 	}

--- a/cmd/prompt_test.go
+++ b/cmd/prompt_test.go
@@ -1,0 +1,72 @@
+//go:build linux
+// +build linux
+
+package cmd
+
+import (
+	"io"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/hinshun/vt10x"
+
+	"knative.dev/kn-plugin-func/docker"
+)
+
+func Test_newPromptForCredentials(t *testing.T) {
+	expectedCreds := docker.Credentials{
+		Username: "testuser",
+		Password: "testpwd",
+	}
+
+	console, _, err := vt10x.NewVT10XConsole()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer console.Close()
+
+	go func() {
+		_, _ = console.ExpectEOF()
+	}()
+
+	go func() {
+		chars := expectedCreds.Username + enter + expectedCreds.Password + enter
+		for _, ch := range chars {
+			_, _ = console.Send(string(ch))
+			time.Sleep(time.Millisecond * 50)
+		}
+	}()
+
+	tests := []struct {
+		name   string
+		in     io.Reader
+		out    io.Writer
+		errOut io.Writer
+	}{
+		{
+			name:   "with non-tty",
+			in:     strings.NewReader(expectedCreds.Username + "\r\n" + expectedCreds.Password + "\r\n"),
+			out:    io.Discard,
+			errOut: io.Discard,
+		},
+		{
+			name:   "with tty",
+			in:     console.Tty(),
+			out:    console.Tty(),
+			errOut: console.Tty(),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			credPrompt := newPromptForCredentials(tt.in, tt.out, tt.errOut)
+			cred, err := credPrompt("example.com")
+			if err != nil {
+				t.Fatal(err)
+			}
+			if cred != expectedCreds {
+				t.Errorf("bad credentials: %+v", cred)
+			}
+		})
+	}
+}


### PR DESCRIPTION
# Changes

- :bug: docker credentials can be now read from non-tty stdin (e.g. from piped input).

/kind bug


**Release Note**

```release-note
fix: docker credentials can be now read from non-tty stdin (e.g. from piped input)
```