### PR TITLE
fix: ignore node_modules for s2i builds

### DIFF
--- a/s2i/builder.go
+++ b/s2i/builder.go
@@ -76,6 +76,13 @@ func (b *Builder) Build(ctx context.Context, f fn.Function) (err error) {
 	cfg.RuntimeImagePullPolicy = api.DefaultRuntimeImagePullPolicy
 	cfg.DockerConfig = s2idocker.GetDefaultDockerConfig()
 
+	// Excludes
+	// Do not include .git, .env, .func or any language-specific cache directories
+	// (node_modules, etc) in the tar file sent to the builder, as this both
+	// bloats the build process and can cause unexpected errors in the resultant
+	// Function.
+	cfg.ExcludeRegExp = "(^|/)\\.git|\\.env|\\.func|node_modules(/|$)"
+
 	// Environment variables
 	// Build Envs have local env var references interpolated then added to the
 	// config as an S2I EnvironmentList struct


### PR DESCRIPTION
- :gift: Exclude certain directories form S2I build tar know to be either unnecessary or error-prone
- :bug:  Error running Node Functions which unecessarily had node_modules sent to the build daemon

Exclude various files and cache directories from S2I builds.  This list may need to be expanded in the future.

/kind bug


Fixes #1018
