### PR TITLE
feat: pack builder images individually configurable

### DIFF
--- a/buildpacks/builder_test.go
+++ b/buildpacks/builder_test.go
@@ -1,0 +1,121 @@
+package buildpacks
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	pack "github.com/buildpacks/pack/pkg/client"
+	fn "knative.dev/kn-plugin-func"
+	. "knative.dev/kn-plugin-func/testing"
+)
+
+// Test_ErrRuntimeRequired ensures that a request to build without a runtime
+// defined for the Function yields an ErrRuntimeRequired
+func Test_ErrRuntimeRequired(t *testing.T) {
+	b := NewBuilder()
+	err := b.Build(context.Background(), fn.Function{})
+
+	if !errors.As(err, &ErrRuntimeRequired{}) {
+		t.Fatalf("expected ErrRuntimeRequired not received. Got %v", err)
+	}
+}
+
+// Test_ErrRuntimeNotSupported ensures that a request to build a function whose
+// runtime is not yet supported yields an ErrRuntimeNotSupported
+func Test_ErrRuntimeNotSupported(t *testing.T) {
+	b := NewBuilder()
+	err := b.Build(context.Background(), fn.Function{Runtime: "unsupported"})
+
+	if !errors.As(err, &ErrRuntimeNotSupported{}) {
+		t.Fatalf("expected ErrRuntimeNotSupported not received. got %v", err)
+	}
+}
+
+// Test_ImageDefault ensures that a Function bing built which does not
+// define a Builder Image will get the internally-defined default.
+func Test_ImageDefault(t *testing.T) {
+	var (
+		i = &mockImpl{}
+		b = NewBuilder(WithImpl(i))
+		f = fn.Function{Runtime: "node"}
+	)
+
+	i.BuildFn = func(ctx context.Context, opts pack.BuildOptions) error {
+		expected := DefaultBuilderImages["node"]
+		if opts.Builder != expected {
+			t.Fatalf("expected pack builder image '%v', got '%v'", expected, opts.Builder)
+		}
+		return nil
+	}
+
+	if err := b.Build(context.Background(), f); err != nil {
+		t.Fatal(err)
+	}
+
+}
+
+// Test_BuilderImageConfigurable ensures that the builder will use the builder
+// image defined on the given Function if provided.
+func Test_BuilderImageConfigurable(t *testing.T) {
+	var (
+		i = &mockImpl{}             // mock underlying implementation
+		b = NewBuilder(WithImpl(i)) // Func Builder logic
+		f = fn.Function{            // Function with a builder image set
+			Runtime: "node",
+			BuilderImages: map[string]string{
+				"pack": "example.com/user/builder-image",
+			},
+		}
+	)
+
+	i.BuildFn = func(ctx context.Context, opts pack.BuildOptions) error {
+		expected := f.BuilderImages["pack"]
+		if opts.Builder != expected {
+			t.Fatalf("expected builder image for node to be '%v', got '%v'", expected, opts.Builder)
+		}
+		return nil
+	}
+
+	if err := b.Build(context.Background(), f); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// Test_BuildEnvs ensures that build environment variables are interpolated and
+// provided in Build Options
+func Test_BuildEnvs(t *testing.T) {
+	defer WithEnvVar(t, "INTERPOLATE_ME", "interpolated")()
+	var (
+		envName  = "NAME"
+		envValue = "{{ env:INTERPOLATE_ME }}"
+		f        = fn.Function{
+			Runtime:   "node",
+			BuildEnvs: []fn.Env{{Name: &envName, Value: &envValue}},
+		}
+		i = &mockImpl{}
+		b = NewBuilder(WithImpl(i))
+	)
+	i.BuildFn = func(ctx context.Context, opts pack.BuildOptions) error {
+		for k, v := range opts.Env {
+			if k == envName && v == "interpolated" {
+				return nil // success!
+			} else if k == envName && v == envValue {
+				t.Fatal("build env was not interpolated")
+			}
+		}
+		t.Fatal("build envs not added to builder options")
+		return nil
+	}
+	if err := b.Build(context.Background(), f); err != nil {
+		t.Fatal(err)
+	}
+}
+
+type mockImpl struct {
+	BuildFn func(context.Context, pack.BuildOptions) error
+}
+
+func (i mockImpl) Build(ctx context.Context, opts pack.BuildOptions) error {
+	return i.BuildFn(ctx, opts)
+}

--- a/client_int_test.go
+++ b/client_int_test.go
@@ -203,7 +203,7 @@ func TestRemoteRepositories(t *testing.T) {
 // newClient creates an instance of the func client whose concrete impls
 // match those created by the kn func plugin CLI.
 func newClient(verbose bool) *fn.Client {
-	builder := buildpacks.NewBuilder(verbose)
+	builder := buildpacks.NewBuilder(buildpacks.WithVerbose(verbose))
 	pusher := docker.NewPusher(docker.WithVerbose(verbose))
 	deployer := knative.NewDeployer(DefaultNamespace, verbose)
 	remover := knative.NewRemover(DefaultNamespace, verbose)

--- a/cmd/build.go
+++ b/cmd/build.go
@@ -158,7 +158,7 @@ func runBuild(cmd *cobra.Command, _ []string, newClient ClientFactory) (err erro
 	// Choose a builder based on the value of the --builder flag
 	var builder fn.Builder
 	if config.Builder == "pack" {
-		builder = buildpacks.NewBuilder(config.Verbose)
+		builder = buildpacks.NewBuilder(buildpacks.WithVerbose(config.Verbose))
 	} else if config.Builder == "s2i" {
 		builder = s2i.NewBuilder(s2i.WithVerbose(config.Verbose))
 	} else {

--- a/cmd/client.go
+++ b/cmd/client.go
@@ -68,7 +68,7 @@ func NewClient(cfg ClientConfig, options ...fn.Option) (*fn.Client, func()) {
 			fn.WithVerbose(cfg.Verbose),
 			fn.WithProgressListener(p),
 			fn.WithTransport(t),
-			fn.WithBuilder(buildpacks.NewBuilder(cfg.Verbose)),
+			fn.WithBuilder(buildpacks.NewBuilder(buildpacks.WithVerbose(cfg.Verbose))),
 			fn.WithRemover(knative.NewRemover(cfg.Namespace, cfg.Verbose)),
 			fn.WithDescriber(knative.NewDescriber(cfg.Namespace, cfg.Verbose)),
 			fn.WithLister(knative.NewLister(cfg.Namespace, cfg.Verbose)),

--- a/pipelines/tekton/resources.go
+++ b/pipelines/tekton/resources.go
@@ -125,7 +125,7 @@ func generatePipelineRun(f fn.Function, labels map[string]string) *pplnv1beta1.P
 				},
 				{
 					Name:  "builderImage",
-					Value: *pplnv1beta1.NewArrayOrString(buildpacks.BuilderImage(f)),
+					Value: *pplnv1beta1.NewArrayOrString(getBuilderImage(f)),
 				},
 			},
 
@@ -153,6 +153,15 @@ func generatePipelineRun(f fn.Function, labels map[string]string) *pplnv1beta1.P
 			},
 		},
 	}
+}
+
+// guilderImage returns the builder image to use when building the Function
+// with the Pack strategy if it can be calculated (the Function has a defined
+// language runtime.  Errors are checked elsewhere, so at this level they
+// manifest as an inability to get a builder image = empty string.
+func getBuilderImage(f fn.Function) (name string) {
+	name, _ = buildpacks.BuilderImage(f)
+	return
 }
 
 func getPipelineName(f fn.Function) string {


### PR DESCRIPTION
# Changes

- :gift: configurable pack builder images via `builderImages` member
- :gift: refactor to enable fuller testing
- :gift: tests

Pack builder can now have its builder image defined in func.yaml (on the Function structure) alongside S2I without interfering with each other.   Previously it was a shared setting, which meant defining a builder image other than the default would peg the Function to only work with one builder or the other.  Also enables per-builder settings, which along with the update to the S2I builder and the [associated func.yaml migration](https://github.com/knative-sandbox/kn-plugin-func/pull/1033), will address #1022. 

/kind enhancement
