### PR TITLE
Better error message for podman auto service

### DIFF
--- a/docker/docker_client.go
+++ b/docker/docker_client.go
@@ -1,6 +1,7 @@
 package docker
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"fmt"
@@ -117,34 +118,62 @@ func newClientWithPodmanService() (dockerClient client.CommonAPIClient, dockerHo
 	dockerHost = fmt.Sprintf("unix://%s", podmanSocket)
 
 	cmd := exec.Command("podman", "system", "service", dockerHost, "--time=0")
+
+	outBuff := bytes.Buffer{}
+	cmd.Stdout = &outBuff
+	cmd.Stderr = &outBuff
+
 	err = cmd.Start()
 	if err != nil {
 		return
 	}
 
+	waitErrCh := make(chan error)
+	go func() { waitErrCh <- cmd.Wait() }()
+
 	dockerClient, err = client.NewClientWithOpts(client.FromEnv, client.WithHost(dockerHost), client.WithAPIVersionNegotiation())
 	stopPodmanService := func() {
 		_ = cmd.Process.Signal(syscall.SIGTERM)
 		_ = os.RemoveAll(tmpDir)
+
+		select {
+		case <-waitErrCh:
+			// the podman service has been shutdown, we don't care about error
+			return
+		case <-time.After(time.Second * 1):
+			// failed to gracefully shutdown the podman service, sending SIGKILL
+			_ = cmd.Process.Signal(syscall.SIGKILL)
+		}
 	}
 	dockerClient = clientWithAdditionalCleanup{
 		CommonAPIClient: dockerClient,
 		cleanUp:         stopPodmanService,
 	}
 
-	podmanServiceRunning := false
-	// give a time to podman to start
-	for i := 0; i < 40; i++ {
-		if _, e := dockerClient.Ping(context.Background()); e == nil {
-			podmanServiceRunning = true
-			break
+	svcUpCh := make(chan struct{})
+	go func() {
+		// give a time to podman to start
+		for i := 0; i < 40; i++ {
+			if _, e := dockerClient.Ping(context.Background()); e == nil {
+				svcUpCh <- struct{}{}
+			}
+			time.Sleep(time.Millisecond * 250)
 		}
-		time.Sleep(time.Millisecond * 250)
-	}
+	}()
 
-	if !podmanServiceRunning {
+	select {
+	case <-svcUpCh:
+		return
+	case <-time.After(time.Second * 10):
 		stopPodmanService()
-		err = errors.New("failed to start podman service")
+		err = errors.New("the podman service has not come up in time")
+	case err = <-waitErrCh:
+		// If this `case` is not selected then the waitErrCh is eventually read by calling stopPodmanService
+		if err != nil {
+			err = fmt.Errorf("failed to start the podman service (cmd out: %q): %w", outBuff.String(), err)
+		} else {
+			err = fmt.Errorf("the podman process had exited before the service come up (cmd out: %q)", outBuff.String())
+		}
 	}
 
 	return

--- a/docker/docker_client.go
+++ b/docker/docker_client.go
@@ -172,7 +172,7 @@ func newClientWithPodmanService() (dockerClient client.CommonAPIClient, dockerHo
 		if err != nil {
 			err = fmt.Errorf("failed to start the podman service (cmd out: %q): %w", outBuff.String(), err)
 		} else {
-			err = fmt.Errorf("the podman process had exited before the service come up (cmd out: %q)", outBuff.String())
+			err = fmt.Errorf("the podman process exited before the service come up (cmd out: %q)", outBuff.String())
 		}
 	}
 


### PR DESCRIPTION
# Changes

:broom: Better error message for `podman` auto service.
 Now we are checking exit code and propagating std[err,out] of the service if something went wrong.