### PR TITLE
feat: on run, build only when filesystem changed

### DIFF
--- a/client.go
+++ b/client.go
@@ -1,7 +1,6 @@
 package function
 
 import (
-	"bytes"
 	"context"
 	"crypto/sha256"
 	"errors"
@@ -956,7 +955,7 @@ func (c *Client) Built(path string) bool {
 // fingerprint returns a hash of the filenames and modification timestamps of
 // the files within a Function's root.
 func fingerprint(f Function) (string, error) {
-	b := bytes.Buffer{}
+	h := sha256.New()
 
 	err := filepath.Walk(f.Root, func(path string, info fs.FileInfo, err error) error {
 		if err != nil {
@@ -968,17 +967,12 @@ func fingerprint(f Function) (string, error) {
 			return filepath.SkipDir
 		}
 
-		// Append full path and modification time to the buffer which will be used
-		// to generate the final fingerprint.
-		b.WriteString(fmt.Sprintf("%v:%v:", path, info.ModTime().UnixNano()))
+		// Write full path and modification timestamp as hash data
+		fmt.Fprintf(h, "%v:%v:", path, info.ModTime().UnixNano())
 		return nil
 	})
-	if err != nil {
-		return "", err
-	}
 
-	sum := sha256.Sum256(b.Bytes())
-	return fmt.Sprintf("%x", sum), nil
+	return fmt.Sprintf("%x", h.Sum(nil)), err
 }
 
 // DEFAULTS

--- a/client.go
+++ b/client.go
@@ -956,22 +956,17 @@ func (c *Client) Built(path string) bool {
 // the files within a Function's root.
 func fingerprint(f Function) (string, error) {
 	h := sha256.New()
-
 	err := filepath.Walk(f.Root, func(path string, info fs.FileInfo, err error) error {
 		if err != nil {
 			return err
 		}
-		// Always ignore .func (runtime data) and .git for purposes of fingerprinting)
-		// NOTE: will be expanded to include all values in .funcignore as well
+		// Always ignore .func, .git (TODO: .funcignore)
 		if info.IsDir() && (info.Name() == ".func" || info.Name() == ".git") {
 			return filepath.SkipDir
 		}
-
-		// Write full path and modification timestamp as hash data
 		fmt.Fprintf(h, "%v:%v:", path, info.ModTime().UnixNano())
 		return nil
 	})
-
 	return fmt.Sprintf("%x", h.Sum(nil)), err
 }
 

--- a/client.go
+++ b/client.go
@@ -573,8 +573,9 @@ func (c *Client) Create(cfg Function) (err error) {
 
 // Tag the Function as having been built
 // This is locally-scoped data, only indicating there presumably exists
-// a container image in the cache the configured builder, thus this info
-// is placed in a .func (non-source controlled) local metadata directory, which is not stritly required to exist, so it is created if needed.
+// a container image in the cache of the the configured builder, thus this info
+// is placed in a .func (non-source controlled) local metadata directory, which
+// is not stritly required to exist, so it is created if needed.
 func updateBuildStamp(f Function) (err error) {
 	if err = ensureRuntimeDir(f); err != nil {
 		return err
@@ -908,7 +909,7 @@ func (c *Client) Push(ctx context.Context, path string) (err error) {
 }
 
 // Built returns true if the given path contains a Function which has been
-// built prior to there being any filesystem modificaitons (is not stale).
+// built without any filesystem modificaitons since (is not stale).
 func (c *Client) Built(path string) bool {
 	f, err := NewFunction(path)
 	if err != nil {
@@ -933,7 +934,7 @@ func (c *Client) Built(path string) bool {
 	buildstampPath := filepath.Join(path, RunDataDir, buildstamp)
 
 	// If there is no build stamp, it is also not built.
-	// This case should be redundante with the above check for an image, but is
+	// This case should be redundant with the above check for an image, but is
 	// temporarily necessary (see the long-winded caviat note above).
 	if _, err := os.Stat(buildstampPath); err != nil {
 		return false

--- a/client_test.go
+++ b/client_test.go
@@ -1324,12 +1324,14 @@ func TestClient_BuiltStamps(t *testing.T) {
 // filesystem changes as indicating the Function is no longer Built (aka stale)
 // This includes modifying timestamps, removing or adding files.
 func TestClient_BuiltDetects(t *testing.T) {
-	root, rm := Mktemp(t)
+	var (
+		ctx      = context.Background()
+		builder  = mock.NewBuilder()
+		client   = fn.New(fn.WithBuilder(builder), fn.WithRegistry(TestRegistry))
+		testfile = "example.go"
+		root, rm = Mktemp(t)
+	)
 	defer rm()
-	ctx := context.Background()
-	builder := mock.NewBuilder()
-	client := fn.New(fn.WithBuilder(builder), fn.WithRegistry(TestRegistry))
-	testfile := "example.go"
 
 	// Create and build a Function
 	if err := client.Create(fn.Function{Runtime: TestRuntime, Root: root}); err != nil {

--- a/client_test.go
+++ b/client_test.go
@@ -1289,7 +1289,7 @@ func TestClient_Instances(t *testing.T) {
 }
 
 // TestClient_BuiltStamps ensures that the client creates and considers a
-// buildstamp on build which reports whther or not a given path contains a built
+// buildstamp on build which reports whether or not a given path contains a built
 // Function.
 func TestClient_BuiltStamps(t *testing.T) {
 	root, rm := Mktemp(t)
@@ -1315,7 +1315,7 @@ func TestClient_BuiltStamps(t *testing.T) {
 		t.Fatal(err)
 	}
 	if !client.Built(root) {
-		t.Fatal("freshly built Funciton should return Built==true")
+		t.Fatal("freshly built Function should return Built==true")
 	}
 }
 

--- a/client_test.go
+++ b/client_test.go
@@ -1362,9 +1362,11 @@ func TestClient_BuiltDetects(t *testing.T) {
 	}
 
 	// Edit the Function's filesystem by adding a file.
-	if _, err := os.Create(filepath.Join(root, testfile)); err != nil {
+	f, err := os.Create(filepath.Join(root, testfile))
+	if err != nil {
 		t.Fatal(err)
 	}
+	f.Close()
 
 	// The system should now detect the Function is stale
 	if client.Built(root) {

--- a/client_test.go
+++ b/client_test.go
@@ -362,7 +362,6 @@ func TestClient_New_RegistryRequired(t *testing.T) {
 	if err = client.New(context.Background(), fn.Function{Root: root}); err == nil {
 		t.Fatal("did not receive expected error creating a Function without specifying Registry")
 	}
-	fmt.Println(err)
 }
 
 // TestClient_New_ImageNameDerived ensures that the full image (tag) of the resultant OCI

--- a/client_test.go
+++ b/client_test.go
@@ -1386,4 +1386,7 @@ func TestClient_BuiltDetects(t *testing.T) {
 	if err := os.Remove(filepath.Join(root, testfile)); err != nil {
 		t.Fatal(err)
 	}
+	if client.Built(root) {
+		t.Fatal("client did not detect a removed file as indicating build staleness")
+	}
 }

--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -95,7 +95,7 @@ func runDeploy(cmd *cobra.Command, _ []string, newClient ClientFactory) (err err
 		return
 	}
 
-	function.Envs, err = mergeEnvs(function.Envs, config.EnvToUpdate, config.EnvToRemove)
+	function.Envs, _, err = mergeEnvs(function.Envs, config.EnvToUpdate, config.EnvToRemove)
 	if err != nil {
 		return
 	}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -287,8 +287,10 @@ func envFromCmd(cmd *cobra.Command) (*util.OrderedMap, []string, error) {
 	return util.NewOrderedMap(), []string{}, nil
 }
 
-func mergeEnvs(envs []fn.Env, envToUpdate *util.OrderedMap, envToRemove []string) ([]fn.Env, error) {
+func mergeEnvs(envs []fn.Env, envToUpdate *util.OrderedMap, envToRemove []string) ([]fn.Env, int, error) {
 	updated := sets.NewString()
+
+	var counter int
 
 	for i := range envs {
 		if envs[i].Name != nil {
@@ -296,6 +298,7 @@ func mergeEnvs(envs []fn.Env, envToUpdate *util.OrderedMap, envToRemove []string
 			if present {
 				envs[i].Value = &value
 				updated.Insert(*envs[i].Name)
+				counter++
 			}
 		}
 	}
@@ -306,6 +309,7 @@ func mergeEnvs(envs []fn.Env, envToUpdate *util.OrderedMap, envToRemove []string
 			n := name
 			v := value
 			envs = append(envs, fn.Env{Name: &n, Value: &v})
+			counter++
 		}
 	}
 
@@ -313,6 +317,7 @@ func mergeEnvs(envs []fn.Env, envToUpdate *util.OrderedMap, envToRemove []string
 		for i, envVar := range envs {
 			if *envVar.Name == name {
 				envs = append(envs[:i], envs[i+1:]...)
+				counter++
 				break
 			}
 		}
@@ -320,10 +325,10 @@ func mergeEnvs(envs []fn.Env, envToUpdate *util.OrderedMap, envToRemove []string
 
 	errMsg := fn.ValidateEnvs(envs)
 	if len(errMsg) > 0 {
-		return []fn.Env{}, fmt.Errorf(strings.Join(errMsg, "\n"))
+		return []fn.Env{}, 0, fmt.Errorf(strings.Join(errMsg, "\n"))
 	}
 
-	return envs, nil
+	return envs, counter, nil
 }
 
 // setPathFlag ensures common text/wording when the --path flag is used

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -146,7 +146,7 @@ func TestRoot_mergeEnvMaps(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := mergeEnvs(tt.args.envs, tt.args.toUpdate, tt.args.toRemove)
+			got, _, err := mergeEnvs(tt.args.envs, tt.args.toUpdate, tt.args.toRemove)
 			if err != nil {
 				t.Errorf("mergeEnvs() for initial vars %v and toUpdate %v and toRemove %v got error %v",
 					tt.args.envs, tt.args.toUpdate, tt.args.toRemove, err)

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -104,13 +104,12 @@ func runRun(cmd *cobra.Command, args []string, newClient ClientFactory) (err err
 	// since the last build).
 	if config.Build == "auto" {
 		if !client.Built(function.Root) {
-			fmt.Println("Detected a Function rebuild is required")
 			if err = client.Build(cmd.Context(), config.Path); err != nil {
 				return
 			}
 		}
 		fmt.Println("Detected Function was already built.  Use --build to override this behavior.")
-		// Otherwise, --build should parse to a falsy value which indicates an explicit
+		// Otherwise, --build should parse to a truthy value which indicates an explicit
 		// override.
 	} else {
 		build, err := strconv.ParseBool(config.Build)
@@ -118,7 +117,6 @@ func runRun(cmd *cobra.Command, args []string, newClient ClientFactory) (err err
 			return fmt.Errorf("invalid value for --build '%v'.  accepts 'auto', 'true' or 'false' (or similarly truthy value)", build)
 		}
 		if build {
-			fmt.Println("Function build requested.  Building.")
 			if err = client.Build(cmd.Context(), config.Path); err != nil {
 				return err
 			}
@@ -162,7 +160,7 @@ type runConfig struct {
 	// Envs passed via cmd to removed
 	EnvToRemove []string
 
-	// Perform build.  Acceptable values are the keyword 'auto', or a falsy
+	// Perform build.  Acceptable values are the keyword 'auto', or a truthy
 	// value such as 'true', 'false, '1' or '0'.
 	Build string
 

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strconv"
 
 	"github.com/ory/viper"
 	"github.com/spf13/cobra"
@@ -19,14 +20,27 @@ func NewRunCmd(newClient ClientFactory) *cobra.Command {
 		Long: `Run the function locally
 
 Runs the function locally in the current directory or in the directory
-specified by --path flag. The function must already have been built with the 'build' command.
+specified by --path flag.
+
+Building
+By default the Function will be built if never built, or if changes are detected
+to the Function's source.  Use --build to override this behavior.
+
 `,
 		Example: `
-# Build function's image first
-{{.Name}} build
-
-# Run it locally as a container
+# Run the Function locally, building if necessary
 {{.Name}} run
+
+# Run the Function, forcing a rebuild of the image.
+#   This is useful when the Function's image was manually deleted, necessitating
+#   A rebuild even when no changes have been made the Function's source.
+{{.Name}} run --build
+
+# Run the Function's existing image, disabling auto-build.
+#   This is useful when filesystem changes have been made, but one wishes to
+#   run the previously built image without rebuilding.
+{{.Name}} run --build=false
+
 `,
 		SuggestFor: []string{"rnu"},
 		PreRunE:    bindEnv("build", "path", "registry"),
@@ -36,7 +50,8 @@ specified by --path flag. The function must already have been built with the 'bu
 		"Environment variable to set in the form NAME=VALUE. "+
 			"You may provide this flag multiple times for setting multiple environment variables. "+
 			"To unset, specify the environment variable name followed by a \"-\" (e.g., NAME-).")
-	cmd.Flags().BoolP("build", "b", false, "Build the function only if the function has not been built before")
+	cmd.Flags().StringP("build", "b", "auto", "Build the function. [auto|true|false].")
+	cmd.Flags().Lookup("build").NoOptDefVal = "true" // --build is equivalient to --build=true
 	cmd.Flags().StringP("registry", "r", GetDefaultRegistry(), "Registry + namespace part of the image if building, ex 'quay.io/myuser' (Env: $FUNC_REGISTRY)")
 	setPathFlag(cmd)
 
@@ -60,14 +75,16 @@ func runRun(cmd *cobra.Command, args []string, newClient ClientFactory) (err err
 		return
 	}
 
-	function.Envs, err = mergeEnvs(function.Envs, config.EnvToUpdate, config.EnvToRemove)
+	var updated int
+	function.Envs, updated, err = mergeEnvs(function.Envs, config.EnvToUpdate, config.EnvToRemove)
 	if err != nil {
 		return
 	}
-
-	err = function.Write()
-	if err != nil {
-		return
+	if updated > 0 {
+		err = function.Write()
+		if err != nil {
+			return
+		}
 	}
 
 	// Check if the Function has been initialized
@@ -81,11 +98,34 @@ func runRun(cmd *cobra.Command, args []string, newClient ClientFactory) (err err
 	client, done := newClient(ClientConfig{Verbose: config.Verbose}, fn.WithRegistry(config.Registry))
 	defer done()
 
-	// Build if not built and --build
-	if config.Build && !function.Built() {
-		if err = client.Build(cmd.Context(), config.Path); err != nil {
-			return
+	// Build?
+	// If --build was set to 'auto', only build if client detects the Function
+	// is stale (has either never been built or has had filesystem modifications
+	// since the last build).
+	if config.Build == "auto" {
+		if !client.Built(function.Root) {
+			fmt.Println("Detected a Function rebuild is required")
+			if err = client.Build(cmd.Context(), config.Path); err != nil {
+				return
+			}
 		}
+		fmt.Println("Detected Function was already built.  Use --build to override this behavior.")
+		// Otherwise, --build should parse to a falsy value which indicates an explicit
+		// override.
+	} else {
+		build, err := strconv.ParseBool(config.Build)
+		if err != nil {
+			return fmt.Errorf("invalid value for --build '%v'.  accepts 'auto', 'true' or 'false' (or similarly truthy value)", build)
+		}
+		if build {
+			fmt.Println("Function build requested.  Building.")
+			if err = client.Build(cmd.Context(), config.Path); err != nil {
+				return err
+			}
+		} else {
+			fmt.Println("Function build disabled.  Skipping build.")
+		}
+
 	}
 
 	// Run the Function at path
@@ -122,8 +162,9 @@ type runConfig struct {
 	// Envs passed via cmd to removed
 	EnvToRemove []string
 
-	// Perform build if function hasn't been built yet
-	Build bool
+	// Perform build.  Acceptable values are the keyword 'auto', or a falsy
+	// value such as 'true', 'false, '1' or '0'.
+	Build string
 
 	// Registry for the build tag if building
 	Registry string
@@ -136,7 +177,7 @@ func newRunConfig(cmd *cobra.Command) (c runConfig, err error) {
 	}
 
 	return runConfig{
-		Build:       viper.GetBool("build"),
+		Build:       viper.GetString("build"),
 		Path:        viper.GetString("path"),
 		Verbose:     viper.GetBool("verbose"), // defined on root
 		Registry:    viper.GetString("registry"),

--- a/function.go
+++ b/function.go
@@ -313,7 +313,7 @@ func (f Function) Initialized() bool {
 // image indicated actually exists, just that it _should_ exist based off
 // the current state of the Function object, in particular the value of
 // the Image and ImageDiget fields.
-func (f Function) Built() bool {
+func (f Function) HasImage() bool {
 	// If Image (the override) and ImageDigest (the most recent build stamp) are
 	// both empty, the Function is considered unbuilt.
 	// TODO: upgrade to a "build complete" timestamp.

--- a/job.go
+++ b/job.go
@@ -6,12 +6,6 @@ import (
 	"path/filepath"
 )
 
-const (
-	// RunDataDir holds transient runtime metadata
-	// By default it is excluded from source control.
-	RunDataDir = ".func"
-)
-
 // Job represents a running Function job (presumably started by this process'
 // Runner instance.
 type Job struct {


### PR DESCRIPTION
:gift: client detects Function build staleness via `.Built(path)`
:gift: `run` command accepts `auto|true|false` for `--build`

Upon build, a hash of the filesystem at time of build is stored in the Function runtime directory `.func`.  This stamp is exposed via a new `.Built` function on the client.

This function is utilized to implement more intelligent build logic on the `run` command as initial acceptance testing, and will be integrated into the `deploy` command in a subsequent PR if acceptable.

/kind enhancement

```release-notes
On `run`, functions are only built when something on the filesystem changes
```