### PR TITLE
fix: increase timeout when testing int cluster availability

### DIFF
--- a/hack/test.sh
+++ b/hack/test.sh
@@ -41,13 +41,17 @@ EOF
       exit 1
     fi
     echo "Retrying..."
-    sleep 5
+    sleep 10
   done
 
-  sleep 60
+  # Sleep to avoid a racing condition where `kubectl wait` below will fail
+  # immediately that the "echo" route is not found and can thus not be waited
+  # upon to complete.
+  sleep 30
 
-  # wait for the route to become ready
-  kubectl wait --for=condition=Ready route echo -n func
+  # Wait for the test to become available
+  echo "${em}  Waiting for echo route${me}"
+  kubectl wait --for=condition=Ready route echo -n func --timeout=120s
 
   echo "${em}  Invoking echo server${me}"
   curl http://echo.func.127.0.0.1.sslip.io/


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

- :bug: fix frequent test timeouts

Of late the "Verify Configuration" step of the integrations tests has been failing.  This appears to be because the cluster made available in GitHub actions simply doesn't stand up the test `echo` service within the 30s default wait timeout.

Until such time as Kubernetes gets faster, or the GitHub VMs are more highly specced... this PR just increases the timeout from the default 30s to 120.  Also increased is the time between attempts to create the service, as it appears to always try 5 or more times before the endpoint is available.

/kind bug