### PR TITLE
fix: map invoke format flag

### DIFF
--- a/cmd/invoke.go
+++ b/cmd/invoke.go
@@ -208,6 +208,7 @@ func newInvokeConfig(newClient ClientFactory) (cfg invokeConfig, err error) {
 	cfg = invokeConfig{
 		Path:        viper.GetString("path"),
 		Target:      viper.GetString("target"),
+		Format:      viper.GetString("format"),
 		ID:          viper.GetString("id"),
 		Source:      viper.GetString("source"),
 		Type:        viper.GetString("type"),


### PR DESCRIPTION
:bug: fix unrespected invoke format flag

Fixes ignored flag `func invoke --format [http|cloudevent]`

Fixes #1037 

/kind bug