### PR TITLE
feat: use JSON object as default message for the invoke sub-command

### DIFF
--- a/invoke.go
+++ b/invoke.go
@@ -17,8 +17,8 @@ import (
 const (
 	DefaultInvokeSource      = "/boson/fn"
 	DefaultInvokeType        = "boson.fn"
-	DefaultInvokeContentType = "text/plain"
-	DefaultInvokeData        = "Hello World"
+	DefaultInvokeContentType = "application/json"
+	DefaultInvokeData        = `{"message":"Hello World"}`
 	DefaultInvokeFormat      = "http"
 )
 


### PR DESCRIPTION
# Changes

Use JSON object as default message for the invoke sub-command

```release-note
Use JSON object (instead of plain text) as default message for the invoke sub-command
```
