### PR TITLE
chore: print correct logs for failed PipelineRun

### DIFF
--- a/pipelines/tekton/pipeplines_provider.go
+++ b/pipelines/tekton/pipeplines_provider.go
@@ -264,7 +264,8 @@ func getFailedPipelineRunLog(ctx context.Context, pr *v1beta1.PipelineRun, names
 		for _, t := range pr.Status.TaskRuns {
 			if t.Status.GetCondition(apis.ConditionSucceeded).Status == corev1.ConditionFalse {
 				for _, s := range t.Status.Steps {
-					if s.Terminated != nil && s.Terminated.ExitCode == 1 {
+					// let's try to print logs of the first unsuccessful step
+					if s.Terminated != nil && s.Terminated.ExitCode != 0 {
 						podLogs, err := k8s.GetPodLogs(ctx, namespace, t.Status.PodName, s.ContainerName)
 						if err == nil {
 							return podLogs


### PR DESCRIPTION
Signed-off-by: Zbynek Roubalik <zroubalik@gmail.com>

<!-- Thanks for sending a pull request! -->

# Changes

If Tekton Task consists of multiple Steps and there is a failure in one of the steps, the `ExitCode` on this step Step is set to `number != 0`.  `ExitCode == 1` is set on the last failed Step.

So if there are for example 3 steps and the 2nd step fails, this causes failure in the 3rd step as well. In this case the ExitCodes are set this way:
```
step1: ExitCode: 0
step2: ExitCode: 145 (and maybe random? number != 0)
step3: ExitCode: 1
```

The previous implementation printed logs for step3, but we are more interested in the step2 logs.  This PR fixes this problem.

