### PR TITLE
remove third-party echo test from CI

### DIFF
--- a/.github/workflows/test-integration.yaml
+++ b/.github/workflows/test-integration.yaml
@@ -21,7 +21,5 @@ jobs:
         run: ./hack/allocate.sh
       - name: Local Registry
         run: ./hack/registry.sh
-      - name: Verify Configuration
-        run: ./hack/test.sh
       - name: Integration Test
         run: make test-integration


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

:bug: remove flaky third-party echo step from CI

Despite having its timeout increased twice, the third-party-dependent echo server test continues to time out regularly in CI.  While still useful when testing locally or in less resource-constrained environments, I propose simply removing this step from GitHub actions.  The E2E tests succeed often even when this validation step does not, indicating the problem is not the cluster itself.

It is perhaps worth noting that, even after repeatedly re-running tests after increasing the timeout, pr #1031 refused to complete.  After removing this test script, everything worked fine.  I suggest that it is useful to retain in the repository for validating local configuration but is too flaky and ultimately redundant when running a full suite of test in CI.  Let's extirpate!

/kind bug
