### PR TITLE
feat: add all build flags to deploy

### DIFF
--- a/client.go
+++ b/client.go
@@ -909,7 +909,7 @@ func (c *Client) Push(ctx context.Context, path string) (err error) {
 }
 
 // Built returns true if the given path contains a Function which has been
-// built without any filesystem modificaitons since (is not stale).
+// built without any filesystem modifications since (is not stale).
 func (c *Client) Built(path string) bool {
 	f, err := NewFunction(path)
 	if err != nil {

--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -61,7 +61,7 @@ that is pushed to an image registry, and finally the function's Knative service 
 	cmd.Flags().StringP("git-dir", "d", "", "Directory in the repo where the function is located (Env: $FUNC_GIT_DIR)")
 	cmd.Flags().StringP("build", "b", fn.DefaultBuildType, fmt.Sprintf("Build specifies the way the function should be built. Supported types are %s (Env: $FUNC_BUILD)", fn.SupportedBuildTypes(true)))
 	// Flags shared with Build specifically related to building:
-	cmd.Flags().StringP("builder", "b", "pack", "build strategy to use when creating the underlying image. Currently supported build strategies are 'pack' and 's2i'.")
+	cmd.Flags().StringP("builder", "", "pack", "build strategy to use when creating the underlying image. Currently supported build strategies are 'pack' and 's2i'.")
 	cmd.Flags().StringP("builder-image", "", "", "builder image, either an as a an image name or a mapping name.\nSpecified value is stored in func.yaml (as 'builder' field) for subsequent builds. ($FUNC_BUILDER_IMAGE)")
 	cmd.Flags().StringP("image", "i", "", "Full image name in the form [registry]/[namespace]/[name]:[tag] (optional). This option takes precedence over --registry (Env: $FUNC_IMAGE)")
 	cmd.Flags().StringP("registry", "r", GetDefaultRegistry(), "Registry + namespace part of the image to build, ex 'quay.io/myuser'.  The full image name is automatically determined based on the local directory name. If not provided the registry will be taken from func.yaml (Env: $FUNC_REGISTRY)")

--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -49,7 +49,7 @@ that is pushed to an image registry, and finally the function's Knative service 
 {{.Name}} deploy --image quay.io/myuser/myfunc -n myns
 `,
 		SuggestFor: []string{"delpoy", "deplyo"},
-		PreRunE:    bindEnv("image", "path", "registry", "confirm", "build", "push", "git-url", "git-branch", "git-dir"),
+		PreRunE:    bindEnv("image", "path", "registry", "confirm", "build", "push", "git-url", "git-branch", "git-dir", "builder", "builder-image"),
 	}
 
 	cmd.Flags().BoolP("confirm", "c", false, "Prompt to confirm all configuration options (Env: $FUNC_CONFIRM)")

--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -17,8 +17,10 @@ import (
 	"knative.dev/client/pkg/util"
 
 	fn "knative.dev/kn-plugin-func"
+	"knative.dev/kn-plugin-func/buildpacks"
 	"knative.dev/kn-plugin-func/docker"
 	"knative.dev/kn-plugin-func/docker/creds"
+	"knative.dev/kn-plugin-func/s2i"
 )
 
 func NewDeployCmd(newClient ClientFactory) *cobra.Command {
@@ -57,13 +59,24 @@ that is pushed to an image registry, and finally the function's Knative service 
 	cmd.Flags().StringP("git-url", "g", "", "Repo url to push the code to be built (Env: $FUNC_GIT_URL)")
 	cmd.Flags().StringP("git-branch", "t", "", "Git branch to be used for remote builds (Env: $FUNC_GIT_BRANCH)")
 	cmd.Flags().StringP("git-dir", "d", "", "Directory in the repo where the function is located (Env: $FUNC_GIT_DIR)")
+	cmd.Flags().StringP("build", "b", fn.DefaultBuildType, fmt.Sprintf("Build specifies the way the function should be built. Supported types are %s (Env: $FUNC_BUILD)", fn.SupportedBuildTypes(true)))
+	// Flags shared with Build specifically related to building:
+	cmd.Flags().StringP("builder", "b", "pack", "build strategy to use when creating the underlying image. Currently supported build strategies are 'pack' and 's2i'.")
+	cmd.Flags().StringP("builder-image", "", "", "builder image, either an as a an image name or a mapping name.\nSpecified value is stored in func.yaml (as 'builder' field) for subsequent builds. ($FUNC_BUILDER_IMAGE)")
 	cmd.Flags().StringP("image", "i", "", "Full image name in the form [registry]/[namespace]/[name]:[tag] (optional). This option takes precedence over --registry (Env: $FUNC_IMAGE)")
 	cmd.Flags().StringP("registry", "r", GetDefaultRegistry(), "Registry + namespace part of the image to build, ex 'quay.io/myuser'.  The full image name is automatically determined based on the local directory name. If not provided the registry will be taken from func.yaml (Env: $FUNC_REGISTRY)")
-	cmd.Flags().StringP("build", "b", fn.DefaultBuildType, fmt.Sprintf("Build specifies the way the function should be built. Supported types are %s (Env: $FUNC_BUILD)", fn.SupportedBuildTypes(true)))
 	cmd.Flags().BoolP("push", "u", true, "Attempt to push the function image to registry before deploying (Env: $FUNC_PUSH)")
 	setPathFlag(cmd)
 
 	if err := cmd.RegisterFlagCompletionFunc("build", CompleteDeployBuildType); err != nil {
+		fmt.Println("internal: error while calling RegisterFlagCompletionFunc: ", err)
+	}
+
+	if err := cmd.RegisterFlagCompletionFunc("builder", CompleteBuildStrategyList); err != nil {
+		fmt.Println("internal: error while calling RegisterFlagCompletionFunc: ", err)
+	}
+
+	if err := cmd.RegisterFlagCompletionFunc("builder-image", CompleteBuilderImageList); err != nil {
 		fmt.Println("internal: error while calling RegisterFlagCompletionFunc: ", err)
 	}
 
@@ -158,8 +171,25 @@ func runDeploy(cmd *cobra.Command, _ []string, newClient ClientFactory) (err err
 		config.Registry = ""
 	}
 
+	// Choose a builder based on the value of the --builder flag
+	var builder fn.Builder
+	if config.Builder == "pack" {
+		builder = buildpacks.NewBuilder(buildpacks.WithVerbose(config.Verbose))
+	} else if config.Builder == "s2i" {
+		builder = s2i.NewBuilder(s2i.WithVerbose(config.Verbose))
+	} else {
+		err = errors.New("unrecognized builder: valid values are: s2i, pack")
+		return
+	}
+
+	// Use the user-provided builder image, if supplied
+	if config.BuilderImage != "" {
+		function.BuilderImages[config.Builder] = config.BuilderImage
+	}
+
 	client, done := newClient(ClientConfig{Namespace: config.Namespace, Verbose: config.Verbose},
-		fn.WithRegistry(config.Registry))
+		fn.WithRegistry(config.Registry),
+		fn.WithBuilder(builder))
 	defer done()
 
 	switch currentBuildType {

--- a/test/e2e_lifecycle_tests.sh
+++ b/test/e2e_lifecycle_tests.sh
@@ -54,7 +54,7 @@ fi
 export E2E_FUNC_BIN_PATH=$(pwd)/func
 
 go clean -testcache
-go test -v -test.v -test.timeout=30m -tags="e2elc" ./test/_e2e/
+go test -v -test.v -test.timeout=45m -tags="e2elc" ./test/_e2e/
 ret=$?
 
 cd $curdir


### PR DESCRIPTION
:gift: add remaining build options to deploy
:broom: increases e2e test timeout to 45m

Adds `builder` and `builder-image` flags to the `deploy` subcommand such that deploying is a full superset of building.

/kind enhancement
