### PR TITLE
chore: fix link to on_cluster_build.md

### DIFF
--- a/docs/function-developers/developers_guide.md
+++ b/docs/function-developers/developers_guide.md
@@ -18,7 +18,7 @@ For a detailed description of the `func.yaml` file that is used for the Function
 
 ## Building Functions on Cluster
 
-For a detailed description of how to build a Function on a cluster with Tekton Pipelines, please see the [On Cluster Build Guide](../reference/on_cluster_build.yaml).
+For a detailed description of how to build a Function on a cluster with Tekton Pipelines, please see the [On Cluster Build Guide](../reference/on_cluster_build.md).
 
 ## Language Guides
 

--- a/docs/function-developers/developers_guide.md
+++ b/docs/function-developers/developers_guide.md
@@ -18,7 +18,7 @@ For a detailed description of the `func.yaml` file that is used for the Function
 
 ## Building Functions on Cluster
 
-For a detailed description of how to build a Function on a cluster with Tekton Pipelines, please see the [On Cluster Build Guide](on_cluster_build.yaml).
+For a detailed description of how to build a Function on a cluster with Tekton Pipelines, please see the [On Cluster Build Guide](../reference/on_cluster_build.yaml).
 
 ## Language Guides
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

# Changes

- Fix link to on_cluster_build.md since its been moved to /reference directory

<!--
In addition, categorize the changes you're making using the "/kind" Prow command, example:

/kind <kind>

Supported kinds are: api-change, bug, cleanup, deprecation, removal, documentation, enhancement, performance

-->
/kind documentation
