### PR TITLE
Do not codecov ./templates

### DIFF
--- a/.codecov.yaml
+++ b/.codecov.yaml
@@ -3,4 +3,5 @@ ignore:
   - vendor
   - testdata
   - docker/zz_close_guarding_client_generated.go
+  - templates
 


### PR DESCRIPTION
# Changes

- :broom: Do not codecov `./templates`. Templates are not tested in a way that supports codecov.