### PR TITLE
Explicit define builder for Remote and Config e2e tests

### DIFF
--- a/test/_e2e/cmd_build_test.go
+++ b/test/_e2e/cmd_build_test.go
@@ -15,7 +15,11 @@ import (
 // Build runs `func build' command for a given test project.
 func Build(t *testing.T, knFunc *TestShellCmdRunner, project *FunctionTestProject) {
 
-	result := knFunc.Exec("build", "--path", project.ProjectPath, "--registry", GetRegistry())
+	buildArgs := []string{"build", "--path", project.ProjectPath, "--registry", GetRegistry()}
+	if project.Builder != "" {
+		buildArgs = append(buildArgs, "--builder", project.Builder)
+	}
+	result := knFunc.Exec(buildArgs...)
 	if result.Error != nil {
 		t.Fail()
 	}

--- a/test/_e2e/cmd_config_envs_test.go
+++ b/test/_e2e/cmd_config_envs_test.go
@@ -104,6 +104,7 @@ func TestConfigEnvs(t *testing.T) {
 	project.FunctionName = "test-config-envs"
 	project.ProjectPath = filepath.Join(os.TempDir(), project.FunctionName)
 	project.RemoteRepository = "http://github.com/boson-project/test-templates.git"
+	project.Builder = "pack"
 
 	Create(t, knFunc.TestShell, project)
 	defer func() { _ = project.RemoveProjectFolder() }()
@@ -164,6 +165,7 @@ func TestConfigEnvs(t *testing.T) {
 
 	// Deploy
 	knFunc.TestShell.WithEnv(testEnvName, testEnvValue)
+	Build(t, knFunc.TestShell, &project)
 	Deploy(t, knFunc.TestShell, &project)
 	defer Delete(t, knFunc.TestShell, &project)
 	ReadyCheck(t, knFunc.TestShell, project)

--- a/test/_e2e/cmd_config_labels_test.go
+++ b/test/_e2e/cmd_config_labels_test.go
@@ -57,6 +57,7 @@ func TestConfigLabel(t *testing.T) {
 	project.Template = "http"
 	project.FunctionName = "test-config-labels"
 	project.ProjectPath = filepath.Join(os.TempDir(), project.FunctionName)
+	project.Builder = "pack"
 
 	Create(t, knFunc.TestShell, project)
 	defer func() { _ = project.RemoveProjectFolder() }()
@@ -75,6 +76,7 @@ func TestConfigLabel(t *testing.T) {
 
 	// Deploy
 	knFunc.TestShell.WithEnv(testEnvName, testEnvValue)
+	Build(t, knFunc.TestShell, &project)
 	Deploy(t, knFunc.TestShell, &project)
 	defer Delete(t, knFunc.TestShell, &project)
 

--- a/test/_e2e/cmd_config_volumes_test.go
+++ b/test/_e2e/cmd_config_volumes_test.go
@@ -101,6 +101,7 @@ func TestConfigVolumes(t *testing.T) {
 	project.FunctionName = "test-config-volumes"
 	project.ProjectPath = filepath.Join(os.TempDir(), project.FunctionName)
 	project.RemoteRepository = "http://github.com/boson-project/test-templates.git"
+	project.Builder = "pack"
 
 	Create(t, knFunc.TestShell, project)
 	defer project.RemoveProjectFolder()
@@ -139,6 +140,7 @@ func TestConfigVolumes(t *testing.T) {
 	configVolumesRemove("/bad-cm", enter)
 
 	// Deploy
+	Build(t, knFunc.TestShell, &project)
 	Deploy(t, knFunc.TestShell, &project)
 	defer Delete(t, knFunc.TestShell, &project)
 	ReadyCheck(t, knFunc.TestShell, project)

--- a/test/_e2e/config.go
+++ b/test/_e2e/config.go
@@ -8,7 +8,7 @@ import (
 // Intended to provide setup configuration for E2E tests
 const (
 	defaultRegistry        = "localhost:50000/user"
-	testTemplateRepository = "http://github.com/lance/test-templates.git" //nolint:varcheck,deadcode
+	testTemplateRepository = "http://github.com/boson-project/test-templates.git" //nolint:varcheck,deadcode
 )
 
 // GetRegistry returns registry

--- a/test/_e2e/e2e_remote_repository_test.go
+++ b/test/_e2e/e2e_remote_repository_test.go
@@ -20,6 +20,7 @@ func TestRemoteRepository(t *testing.T) {
 	project.Template = "e2e"
 	project.FunctionName = "func-remote-repo"
 	project.ProjectPath = filepath.Join(os.TempDir(), project.FunctionName)
+	project.Builder = "pack"
 
 	result := knFunc.Exec("create", project.ProjectPath,
 		"--language", project.Runtime,

--- a/test/_e2e/func_test_proj.go
+++ b/test/_e2e/func_test_proj.go
@@ -22,6 +22,8 @@ type FunctionTestProject struct {
 	Template string
 	// Git Location of a Remote Repository used to pull the template
 	RemoteRepository string
+	// Indicates which builder should be uses (i.e: pack|s2i)
+	Builder string
 	// Indicates function is already built
 	IsBuilt bool
 	// Indicates function is already deployed


### PR DESCRIPTION

# Changes

- :broom: Defines builder for e2e tests tied to GoLang functions such a Test Remote Repository, Config Envs, Labels and Volumes
kind <kind>

/kind cleanup


