### PR TITLE
feat: check valid runtimes for on cluster build

### DIFF
--- a/pipelines/tekton/pipeplines_provider.go
+++ b/pipelines/tekton/pipeplines_provider.go
@@ -11,7 +11,7 @@ import (
 	"github.com/tektoncd/cli/pkg/taskrun"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/errors"
+	errors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	k8slabels "k8s.io/apimachinery/pkg/labels"
@@ -74,6 +74,10 @@ func NewPipelinesProvider(opts ...Opt) *PipelinesProvider {
 // After the PipelineRun is being intitialized, the progress of the PipelineRun is being watched and printed to the output.
 func (pp *PipelinesProvider) Run(ctx context.Context, f fn.Function) error {
 	pp.progressListener.Increment("Creating Pipeline resources")
+
+	if err := validatePipeline(f); err != nil {
+		return err
+	}
 
 	client, namespace, err := NewTektonClientAndResolvedNamespace(pp.namespace)
 	if err != nil {

--- a/pipelines/tekton/pipeplines_provider.go
+++ b/pipelines/tekton/pipeplines_provider.go
@@ -11,7 +11,7 @@ import (
 	"github.com/tektoncd/cli/pkg/taskrun"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
 	corev1 "k8s.io/api/core/v1"
-	errors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	k8slabels "k8s.io/apimachinery/pkg/labels"

--- a/pipelines/tekton/validate.go
+++ b/pipelines/tekton/validate.go
@@ -1,0 +1,39 @@
+package tekton
+
+import (
+	"errors"
+	"fmt"
+
+	fn "knative.dev/kn-plugin-func"
+)
+
+var (
+	// ErrRuntimeRequired indicates the required value of Function Runtime was not provided
+	ErrRuntimeRequired = errors.New("runtime is required to build")
+
+	ErrBuilpacksNotSupported = errors.New("additional Buildpacks are not supported for on cluster build")
+)
+
+type ErrRuntimeNotSupported struct {
+	Runtime string
+}
+
+func (e ErrRuntimeNotSupported) Error() string {
+	return fmt.Sprintf("runtime %q is not supported for on cluster build", e.Runtime)
+}
+
+func validatePipeline(f fn.Function) error {
+	if f.Runtime == "" {
+		return ErrRuntimeRequired
+	}
+
+	if f.Runtime == "go" || f.Runtime == "rust" || f.Runtime == "quarkus" {
+		return ErrRuntimeNotSupported{f.Runtime}
+	}
+
+	if len(f.Buildpacks) > 0 {
+		return ErrBuilpacksNotSupported
+	}
+
+	return nil
+}

--- a/pipelines/tekton/validate_test.go
+++ b/pipelines/tekton/validate_test.go
@@ -1,0 +1,72 @@
+//go:build !integration
+// +build !integration
+
+package tekton
+
+import (
+	"testing"
+
+	fn "knative.dev/kn-plugin-func"
+)
+
+func Test_validatePipeline(t *testing.T) {
+
+	testBuildpacks := []string{"quay.io/foo/my-buildpack"}
+
+	tests := []struct {
+		name     string
+		function fn.Function
+		wantErr  bool
+	}{
+		{
+			name:     "Without runtime - without additional Buildpacks",
+			function: fn.Function{},
+			wantErr:  true,
+		},
+		{
+			name:     "Without runtime - with additional Buildpacks",
+			function: fn.Function{Buildpacks: testBuildpacks},
+			wantErr:  true,
+		},
+		{
+			name:     "Supported runtime - without additional Buildpacks",
+			function: fn.Function{Runtime: "node"},
+			wantErr:  false,
+		},
+		{
+			name:     "Supported runtime - with additional Buildpacks",
+			function: fn.Function{Runtime: "node", Buildpacks: testBuildpacks},
+			wantErr:  true,
+		},
+		{
+			name:     "Unsupported runtime - Go - without additional Buildpacks",
+			function: fn.Function{Runtime: "go"},
+			wantErr:  true,
+		},
+		{
+			name:     "Unsupported runtime - Quarkus - without additional Buildpacks",
+			function: fn.Function{Runtime: "quarkus"},
+			wantErr:  true,
+		},
+		{
+			name:     "Unsupported runtime - Rust - without additional Buildpacks",
+			function: fn.Function{Runtime: "rust"},
+			wantErr:  true,
+		},
+		{
+			name:     "Unsupported runtime - Go - with additional Buildpacks",
+			function: fn.Function{Runtime: "go", Buildpacks: testBuildpacks},
+			wantErr:  true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validatePipeline(tt.function)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("validatePipeline() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+		})
+	}
+}


### PR DESCRIPTION
Signed-off-by: Zbynek Roubalik <zroubalik@gmail.com>


Until we resolve issue with additional Buildpacks, a few runtimes are not supported for on cluster build. So it is better to fail before executing the actual Pipeline.