### PR TITLE
feat: func deploy accepts image digest in --image

### DIFF
--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -504,20 +504,12 @@ func parseImageDigest(imageSplit []string, config deployConfig, cmd *cobra.Comma
 		return config, fmt.Errorf("the --build flag '%s' is not valid when using --image with digest", config.BuildType)
 	}
 
-	// if --build was not explicitly set via CLI, print a warning
-	if config.BuildType == "" {
-		fmt.Printf("Warning: --build flag not set when using --image with digest, setting to 'disabled'\n")
-	}
-
 	// if the --push flag was set by a user to 'true', return an error
 	if cmd.Flags().Changed("push") && config.Push {
 		return config, fmt.Errorf("the --push flag '%v' is not valid when using --image with digest", config.Push)
 	}
 
-	// if the --push flag was not set by a user, print a warning
-	if !cmd.Flags().Changed("push") {
-		fmt.Printf("Warning: --push flag not set when using --image with digest, setting to 'false'\n")
-	}
+	fmt.Printf("Deploying existing image with digest %s. Build and push are disabled.\n", imageSplit[1])
 
 	config.BuildType = "disabled"
 	config.Push = false

--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -114,18 +114,19 @@ func runDeploy(cmd *cobra.Command, _ []string, newClient ClientFactory) (err err
 		}
 
 		if len(imageSplit[1][7:]) != 64 {
-			return fmt.Errorf("sha256 hash '%s' from --image has the wrong length (%d), should be 64", imageSplit[1], len(imageSplit[1][7:]))
+			return fmt.Errorf("sha256 hash in '%s' from --image has the wrong length (%d), should be 64", imageSplit[1], len(imageSplit[1][7:]))
 		}
 
 		config.Image = imageSplit[0]
 
+		// if BuidType was not explicitly set via CLI, set to 'disabled' without an error
 		if config.BuildType != "" && config.BuildType != "disabled" {
 			return fmt.Errorf("build type '%s' is not accepted with --image with digest. Use 'disabled' or none", config.BuildType)
 		}
 		config.BuildType = "disabled"
 
 		if config.Push {
-			return fmt.Errorf("--image was specified with digest, therefore push is not allowed")
+			return fmt.Errorf("--image was specified with digest, therefore --push is not allowed")
 		}
 	}
 

--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -63,7 +63,7 @@ that is pushed to an image registry, and finally the function's Knative service 
 	// Flags shared with Build specifically related to building:
 	cmd.Flags().StringP("builder", "", "pack", "build strategy to use when creating the underlying image. Currently supported build strategies are 'pack' and 's2i'.")
 	cmd.Flags().StringP("builder-image", "", "", "builder image, either an as a an image name or a mapping name.\nSpecified value is stored in func.yaml (as 'builder' field) for subsequent builds. ($FUNC_BUILDER_IMAGE)")
-	cmd.Flags().StringP("image", "i", "", "Full image name in the form [registry]/[namespace]/[name]:[tag]@[digest] (optional). This option takes precedence over --registry (Env: $FUNC_IMAGE). If digest is given, build and push are disabled.")
+	cmd.Flags().StringP("image", "i", "", "Full image name in the form [registry]/[namespace]/[name]:[tag]@[digest]. This option takes precedence over --registry. Specifying digest is optional, but if it is given, 'build' and 'push' phases are disabled. (Env: $FUNC_IMAGE)")
 	cmd.Flags().StringP("registry", "r", GetDefaultRegistry(), "Registry + namespace part of the image to build, ex 'quay.io/myuser'.  The full image name is automatically determined based on the local directory name. If not provided the registry will be taken from func.yaml (Env: $FUNC_REGISTRY)")
 	cmd.Flags().BoolP("push", "u", true, "Attempt to push the function image to registry before deploying (Env: $FUNC_PUSH)")
 	setPathFlag(cmd)

--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -63,7 +63,7 @@ that is pushed to an image registry, and finally the function's Knative service 
 	// Flags shared with Build specifically related to building:
 	cmd.Flags().StringP("builder", "", "pack", "build strategy to use when creating the underlying image. Currently supported build strategies are 'pack' and 's2i'.")
 	cmd.Flags().StringP("builder-image", "", "", "builder image, either an as a an image name or a mapping name.\nSpecified value is stored in func.yaml (as 'builder' field) for subsequent builds. ($FUNC_BUILDER_IMAGE)")
-	cmd.Flags().StringP("image", "i", "", "Full image name in the form [registry]/[namespace]/[name]:[tag] (optional). This option takes precedence over --registry (Env: $FUNC_IMAGE)")
+	cmd.Flags().StringP("image", "i", "", "Full image name in the form [registry]/[namespace]/[name]:[tag]@[digest] (optional). This option takes precedence over --registry (Env: $FUNC_IMAGE). If digest is given, build and push have to be disabled.")
 	cmd.Flags().StringP("registry", "r", GetDefaultRegistry(), "Registry + namespace part of the image to build, ex 'quay.io/myuser'.  The full image name is automatically determined based on the local directory name. If not provided the registry will be taken from func.yaml (Env: $FUNC_REGISTRY)")
 	cmd.Flags().BoolP("push", "u", true, "Attempt to push the function image to registry before deploying (Env: $FUNC_PUSH)")
 	setPathFlag(cmd)
@@ -103,9 +103,40 @@ func runDeploy(cmd *cobra.Command, _ []string, newClient ClientFactory) (err err
 		return
 	}
 
+	//if --image contains '@', validate image digest and disable build if valid, otherwise return an error
+	imageSplit := strings.Split(config.Image, "@")
+	imageDigestProvided := false
+	if len(imageSplit) == 2 {
+		imageDigestProvided = true
+
+		if !strings.HasPrefix(imageSplit[1], "sha256:") {
+			return fmt.Errorf("value '%s' in --image has invalid prefix syntax for digest (should be 'sha256:')", config.Image)
+		}
+
+		if len(imageSplit[1][7:]) != 64 {
+			return fmt.Errorf("sha256 hash '%s' from --image has the wrong length (%d), should be 64", imageSplit[1], len(imageSplit[1][7:]))
+		}
+
+		config.Image = imageSplit[0]
+
+		if config.BuildType != "" && config.BuildType != "disabled" {
+			return fmt.Errorf("build type '%s' is not accepted with --image with digest. Use 'disabled' or none", config.BuildType)
+		}
+		config.BuildType = "disabled"
+
+		if config.Push {
+			return fmt.Errorf("--image was specified with digest, therefore push is not allowed")
+		}
+	}
+
 	function, err := functionWithOverrides(config.Path, functionOverrides{Namespace: config.Namespace, Image: config.Image})
 	if err != nil {
 		return
+	}
+
+	// save image digest if provided in --image
+	if imageDigestProvided {
+		function.ImageDigest = imageSplit[1]
 	}
 
 	function.Envs, _, err = mergeEnvs(function.Envs, config.EnvToUpdate, config.EnvToRemove)

--- a/cmd/deploy_test.go
+++ b/cmd/deploy_test.go
@@ -202,7 +202,7 @@ runtime: go`,
 			name:      "valid image name, build not 'disabled', expect error",
 			image:     "docker.io/4141gauron3268/static_test_digest:latest@sha256:7d66645b0add6de7af77ef332ecd4728649a2f03b9a2716422a054805b595c4e",
 			buildType: "local",
-			errString: "build type 'local' is not accepted with --image with digest. Use 'disabled' or none",
+			errString: "the --build flag 'local' is not valid when using --image with digest",
 			funcFile: `name: test-func
 runtime: go`,
 		},
@@ -210,7 +210,7 @@ runtime: go`,
 			name:      "valid image name, --push specified, expect error",
 			image:     "docker.io/4141gauron3268/static_test_digest:latest@sha256:7d66645b0add6de7af77ef332ecd4728649a2f03b9a2716422a054805b595c4e",
 			pushBool:  true,
-			errString: "--image was specified with digest, therefore --push is not allowed",
+			errString: "the --push flag 'true' is not valid when using --image with digest",
 			funcFile: `name: test-func
 runtime: go`,
 		},
@@ -237,12 +237,21 @@ runtime: go`,
 					fn.WithDeployer(deployer))
 			}))
 
-			// set flags manually & reset after
-			cmd.SetArgs([]string{
-				fmt.Sprintf("--image=%s", tt.image),
-				fmt.Sprintf("--build=%s", tt.buildType),
-				fmt.Sprintf("--push=%t", tt.pushBool),
-			})
+			// Set flags manually & reset after.
+			// Differs whether build was set via CLI (gives an error if not 'disabled')
+			// or not (prints just a warning)
+			if tt.buildType == "" {
+				cmd.SetArgs([]string{
+					fmt.Sprintf("--image=%s", tt.image),
+					fmt.Sprintf("--push=%t", tt.pushBool),
+				})
+			} else {
+				cmd.SetArgs([]string{
+					fmt.Sprintf("--image=%s", tt.image),
+					fmt.Sprintf("--build=%s", tt.buildType),
+					fmt.Sprintf("--push=%t", tt.pushBool),
+				})
+			}
 			defer cmd.ResetFlags()
 
 			// set test case's func.yaml

--- a/cmd/deploy_test.go
+++ b/cmd/deploy_test.go
@@ -193,14 +193,14 @@ func Test_imageWithDigest(t *testing.T) {
 	}{
 		{
 			name:      "valid full name with digest, expect success",
-			image:     "docker.io/4141gauron3268/app:latest@sha256:59294b4d7dfb96c3e589376a360b9019e1887e7538d50ceda877084910c1c838",
+			image:     "docker.io/4141gauron3268/static_test_digest:latest@sha256:7d66645b0add6de7af77ef332ecd4728649a2f03b9a2716422a054805b595c4e",
 			errString: "",
 			funcFile: `name: test-func
 runtime: go`,
 		},
 		{
 			name:      "valid image name, build not 'disabled', expect error",
-			image:     "docker.io/4141gauron3268/app:latest@sha256:59294b4d7dfb96c3e589376a360b9019e1887e7538d50ceda877084910c1c838",
+			image:     "docker.io/4141gauron3268/static_test_digest:latest@sha256:7d66645b0add6de7af77ef332ecd4728649a2f03b9a2716422a054805b595c4e",
 			buildType: "local",
 			errString: "build type 'local' is not accepted with --image with digest. Use 'disabled' or none",
 			funcFile: `name: test-func
@@ -208,7 +208,7 @@ runtime: go`,
 		},
 		{
 			name:      "valid image name, --push specified, expect error",
-			image:     "docker.io/4141gauron3268/app:latest@sha256:59294b4d7dfb96c3e589376a360b9019e1887e7538d50ceda877084910c1c838",
+			image:     "docker.io/4141gauron3268/static_test_digest:latest@sha256:7d66645b0add6de7af77ef332ecd4728649a2f03b9a2716422a054805b595c4e",
 			pushBool:  true,
 			errString: "--image was specified with digest, therefore --push is not allowed",
 			funcFile: `name: test-func
@@ -216,15 +216,15 @@ runtime: go`,
 		},
 		{
 			name:      "invalid digest prefix, expect error",
-			image:     "docker.io/4141gauron3268/app:latest@Xsha256:59294b4d7dfb96c3e589376a360b9019e1887e7538d50ceda877084910c1c838",
-			errString: "value 'docker.io/4141gauron3268/app:latest@Xsha256:59294b4d7dfb96c3e589376a360b9019e1887e7538d50ceda877084910c1c838' in --image has invalid prefix syntax for digest (should be 'sha256:')",
+			image:     "docker.io/4141gauron3268/static_test_digest:latest@Xsha256:7d66645b0add6de7af77ef332ecd4728649a2f03b9a2716422a054805b595c4e",
+			errString: "value 'docker.io/4141gauron3268/static_test_digest:latest@Xsha256:7d66645b0add6de7af77ef332ecd4728649a2f03b9a2716422a054805b595c4e' in --image has invalid prefix syntax for digest (should be 'sha256:')",
 			funcFile: `name: test-func
 runtime: go`,
 		},
 		{
 			name:      "invalid sha hash length(added X at the end), expect error",
-			image:     "docker.io/4141gauron3268/app:latest@sha256:59294b4d7dfb96c3e589376a360b9019e1887e7538d50ceda877084910c1c838X",
-			errString: "sha256 hash in 'sha256:59294b4d7dfb96c3e589376a360b9019e1887e7538d50ceda877084910c1c838X' from --image has the wrong length (65), should be 64",
+			image:     "docker.io/4141gauron3268/static_test_digest:latest@sha256:7d66645b0add6de7af77ef332ecd4728649a2f03b9a2716422a054805b595c4eX",
+			errString: "sha256 hash in 'sha256:7d66645b0add6de7af77ef332ecd4728649a2f03b9a2716422a054805b595c4eX' from --image has the wrong length (65), should be 64",
 			funcFile: `name: test-func
 runtime: go`,
 		},


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

# Changes
*changes for func deploy*
- --image allows image digest for func deploy as [registry]/[namespace]/[name]:[tag]@[digest]
- if digest is given, push and build have to be disabled and image with digest is saved in func.yaml file
- few tests in deploy_test.go included

/kind enhancement

Fixes #1058 