### PR TITLE
fix: use 0 group id for func-buildpacks Task

### DIFF
--- a/pipelines/resources/tekton/task/func-buildpacks/0.1/func-buildpacks.yaml
+++ b/pipelines/resources/tekton/task/func-buildpacks/0.1/func-buildpacks.yaml
@@ -58,7 +58,9 @@ spec:
       default: "1000"
     - name: GROUP_ID
       description: The group ID of the builder image user.
-      default: "1000"
+      default: "0"
+      ##############################################################
+      #####  "default" has been changed to "0" for Knative Functions
     - name: PLATFORM_DIR
       description: The name of the platform directory.
       default: empty-dir
@@ -87,8 +89,8 @@ spec:
           chown -R "$(params.USER_ID):$(params.GROUP_ID)" "$(workspaces.cache.path)"
         fi
 
-        ############################################
-        #  "/emptyDir" has been added for Knative Functions
+        #######################################################
+        #####  "/emptyDir" has been added for Knative Functions
         for path in "/tekton/home" "/layers" "/emptyDir" "$(workspaces.source.path)"; do
           echo "> Setting permissions on '$path'..."
           chown -R "$(params.USER_ID):$(params.GROUP_ID)" "$path"
@@ -143,8 +145,8 @@ spec:
           mountPath: /layers
         - name: $(params.PLATFORM_DIR)
           mountPath: /platform
-          ############################################
-          #   "/emptyDir" has been added for Knative Functions
+          ########################################################
+          #####   "/emptyDir" has been added for Knative Functions
         - name: empty-dir
           mountPath: /emptyDir
 
@@ -176,7 +178,9 @@ spec:
           mountPath: /platform
       securityContext:
         runAsUser: 1000
-        runAsGroup: 1000
+        #################################################################
+        #####  "runAsGroup" has been changed to "0" for Knative Functions
+        runAsGroup: 0
 
     - name: results
       image: docker.io/library/bash:5.1.4@sha256:b208215a4655538be652b2769d82e576bc4d0a2bb132144c060efc5be8c3f5d6
@@ -213,8 +217,8 @@ spec:
       volumeMounts:
         - name: layers-dir
           mountPath: /layers
-          ############################################
-          #   "/emptyDir" has been added for Knative Functions
+          ########################################################
+          #####   "/emptyDir" has been added for Knative Functions
         - name: empty-dir
           mountPath: /emptyDir
 


### PR DESCRIPTION
Signed-off-by: Zbynek Roubalik <zroubalik@gmail.com>

<!-- Thanks for sending a pull request! -->

# Changes

<!-- 
Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! 

- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

- :broom: use 0 group id for func-buildpacks Task


Previous setting caused problems on some restricted setups (OpenShift in non default namespace). Now the resulting image produced on cluster via Buildpacks Task has the same guid set like image produced locally.

Node function build with the original setup might not be deployed, because of this error:
```
2022/07/11 21:16:18 unlinkat /workspace/source/node_modules: permission denied
[31;1mERROR: [0mfailed to launch: exec.d: failed to execute exec.d file at path '/layers/paketo-buildpacks_npm-install/launch-modules/exec.d/0-setup-symlinks': exit status 1
```


