### PR TITLE
feat: add OpenShift related Annotations & Labels

### DIFF
--- a/client_int_test.go
+++ b/client_int_test.go
@@ -205,7 +205,7 @@ func TestRemoteRepositories(t *testing.T) {
 func newClient(verbose bool) *fn.Client {
 	builder := buildpacks.NewBuilder(buildpacks.WithVerbose(verbose))
 	pusher := docker.NewPusher(docker.WithVerbose(verbose))
-	deployer := knative.NewDeployer(DefaultNamespace, verbose)
+	deployer := knative.NewDeployer(knative.WithDeployerNamespace(DefaultNamespace), knative.WithDeployerVerbose(verbose))
 	remover := knative.NewRemover(DefaultNamespace, verbose)
 	lister := knative.NewLister(DefaultNamespace, verbose)
 

--- a/openshift/metadata.go
+++ b/openshift/metadata.go
@@ -1,0 +1,38 @@
+package openshift
+
+import (
+	fn "knative.dev/kn-plugin-func"
+)
+
+const (
+	AnnotationOpenShiftVcsUri = "app.openshift.io/vcs-uri"
+	AnnotationOpenShiftVcsRef = "app.openshift.io/vcs-ref"
+
+	LabelAppK8sInstance = "app.kubernetes.io/instance"
+)
+
+type OpenshiftMetadataDecorator struct{}
+
+func (o OpenshiftMetadataDecorator) UpdateAnnotations(f fn.Function, annotations map[string]string) map[string]string {
+	if annotations == nil {
+		annotations = map[string]string{}
+	}
+	if f.Git.URL != nil {
+		annotations[AnnotationOpenShiftVcsUri] = *f.Git.URL
+	}
+	if f.Git.Revision != nil {
+		annotations[AnnotationOpenShiftVcsRef] = *f.Git.Revision
+	}
+
+	return annotations
+}
+
+func (o OpenshiftMetadataDecorator) UpdateLabels(f fn.Function, labels map[string]string) map[string]string {
+	if labels == nil {
+		labels = map[string]string{}
+	}
+
+	labels[LabelAppK8sInstance] = f.Name
+
+	return labels
+}


### PR DESCRIPTION
Signed-off-by: Zbynek Roubalik <zroubalik@gmail.com>

<!-- Thanks for sending a pull request! -->

# Changes

<!-- 
Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! 

- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

- :gift: add OpenShift related Annotations & Labels

<!--
In addition, categorize the changes you're making using the "/kind" Prow command, example:

/kind <kind>

Supported kinds are: api-change, bug, cleanup, deprecation, removal, documentation, enhancement, performance

-->
/kind enhancement

This should enable some OpenShift Developer Console UX features (Pipeline and Git Repo references) for on cluster builds:
<img width="1487" alt="fn-pipeline-ui" src="https://user-images.githubusercontent.com/726523/178374813-4d9fbb91-4943-435f-a5f9-eb47aa14e4ae.png">