### PR TITLE
feat: always store namespace in func.yaml and warn if current ns & func.yaml ns is different

### DIFF
--- a/cmd/build_test.go
+++ b/cmd/build_test.go
@@ -154,6 +154,9 @@ created: 2009-11-10 23:00:00`,
 }
 
 func testBuilderPersistence(t *testing.T, testRegistry string, cmdBuilder func(ClientFactory) *cobra.Command) {
+	//add this to work with all other tests in deploy_test.go
+	defer WithEnvVar(t, "KUBECONFIG", fmt.Sprintf("%s/testdata/kubeconfig_deploy_namespace", cwd()))()
+
 	root, rm := Mktemp(t)
 	defer rm()
 

--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -559,7 +559,7 @@ func parseImageDigest(imageSplit []string, config deployConfig, cmd *cobra.Comma
 }
 
 // checkNamespaceDeploy checks current namespace against func.yaml and warns if its different
-// or sets namespace to be writen in func.yaml if its the first deployment
+// or sets namespace to be written in func.yaml if its the first deployment
 func checkNamespaceDeploy(funcNamespace string, confNamespace string) (string, error) {
 	currNamespace, err := k8s.GetNamespace("")
 	if err != nil {

--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -127,7 +127,7 @@ func runDeploy(cmd *cobra.Command, _ []string, newClient ClientFactory) (err err
 	}
 
 	// add ns to func.yaml on first deploy and warn if current context differs from func.yaml
-	function, err = checkNamespaceDeploy(function, config)
+	function.Namespace, err = checkNamespaceDeploy(function.Namespace, config.Namespace)
 	if err != nil {
 		return
 	}
@@ -559,21 +559,21 @@ func parseImageDigest(imageSplit []string, config deployConfig, cmd *cobra.Comma
 }
 
 // checkNamespaceDeploy checks current namespace against func.yaml and warns if its different
-func checkNamespaceDeploy(f fn.Function, c deployConfig) (fn.Function, error) {
+func checkNamespaceDeploy(funcNamespace string, confNamespace string) (string, error) {
 	currNamespace, err := k8s.GetNamespace("")
 	if err != nil {
-		return f, err
+		return funcNamespace, err
 	}
 
 	// If ns exists in func.yaml & NOT given via CLI (--namespace flag) & current ns does NOT match func.yaml ns
-	if f.Namespace != "" && c.Namespace == "" && (currNamespace != f.Namespace) {
-		fmt.Printf("Warning: Current namespace '%s' does not match namespace '%s' in func.yaml. Function is deployed at '%s' namespace\n", currNamespace, f.Namespace, f.Namespace)
+	if funcNamespace != "" && confNamespace == "" && (currNamespace != funcNamespace) {
+		fmt.Printf("Warning: Current namespace '%s' does not match namespace '%s' in func.yaml. Function is deployed at '%s' namespace\n", currNamespace, funcNamespace, funcNamespace)
 	}
 
 	// Add current namespace to func.yaml if it is NOT set yet & NOT given via --namespace.
-	if f.Namespace == "" {
-		f.Namespace = currNamespace
+	if funcNamespace == "" {
+		funcNamespace = currNamespace
 	}
 
-	return f, nil
+	return funcNamespace, nil
 }

--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -559,6 +559,7 @@ func parseImageDigest(imageSplit []string, config deployConfig, cmd *cobra.Comma
 }
 
 // checkNamespaceDeploy checks current namespace against func.yaml and warns if its different
+// or sets namespace to be writen in func.yaml if its the first deployment
 func checkNamespaceDeploy(funcNamespace string, confNamespace string) (string, error) {
 	currNamespace, err := k8s.GetNamespace("")
 	if err != nil {

--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -568,7 +568,7 @@ func checkNamespaceDeploy(funcNamespace string, confNamespace string) (string, e
 
 	// If ns exists in func.yaml & NOT given via CLI (--namespace flag) & current ns does NOT match func.yaml ns
 	if funcNamespace != "" && confNamespace == "" && (currNamespace != funcNamespace) {
-		fmt.Printf("Warning: Current namespace '%s' does not match namespace '%s' in func.yaml. Function is deployed at '%s' namespace\n", currNamespace, funcNamespace, funcNamespace)
+		fmt.Fprintf(os.Stderr, "Warning: Current namespace '%s' does not match namespace '%s' in func.yaml. Function is deployed at '%s' namespace\n", currNamespace, funcNamespace, funcNamespace)
 	}
 
 	// Add current namespace to func.yaml if it is NOT set yet & NOT given via --namespace.

--- a/cmd/deploy_test.go
+++ b/cmd/deploy_test.go
@@ -101,6 +101,8 @@ created: 2009-11-10 23:00:00`,
 			errString: "remote git arguments require the --build=git flag",
 		},
 	}
+
+	defer WithEnvVar(t, "KUBECONFIG", fmt.Sprintf("%s/testdata/kubeconfig_deploy_namespace", cwd()))()
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			var captureFn fn.Function
@@ -229,6 +231,8 @@ runtime: go`,
 runtime: go`,
 		},
 	}
+
+	defer WithEnvVar(t, "KUBECONFIG", fmt.Sprintf("%s/testdata/kubeconfig_deploy_namespace", cwd()))()
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			deployer := mock.NewDeployer()
@@ -319,8 +323,9 @@ runtime: go`,
 		},
 	}
 
-	// save current dir to use later when tempdir is set
-	testPath := cwd()
+	// create mock kubeconfig with set namespace as 'default'
+	defer WithEnvVar(t, "KUBECONFIG", fmt.Sprintf("%s/testdata/kubeconfig_deploy_namespace", cwd()))()
+
 	for _, tt := range tests {
 
 		t.Run(tt.name, func(t *testing.T) {
@@ -330,9 +335,6 @@ runtime: go`,
 				return fn.New(
 					fn.WithDeployer(deployer))
 			}))
-
-			// create mock kubeconfig with set namespace as 'default'
-			defer WithEnvVar(t, "KUBECONFIG", fmt.Sprintf("%s/testdata/kubeconfig_deploy_namespace", testPath))()
 
 			// set namespace argument if given & reset after
 			cmd.SetArgs([]string{}) // Do not use test command args

--- a/cmd/deploy_test.go
+++ b/cmd/deploy_test.go
@@ -276,3 +276,90 @@ runtime: go`,
 func TestDeploy_BuilderPersistence(t *testing.T) {
 	testBuilderPersistence(t, "docker.io/tigerteam", NewDeployCmd)
 }
+
+func Test_namespaceCheck(t *testing.T) {
+	tests := []struct {
+		name      string
+		registry  string
+		namespace string
+		funcFile  string
+		expectNS  string
+	}{
+		{
+			name:     "first deployment(no ns in func.yaml), not given via cli, expect write in func.yaml",
+			registry: "docker.io/4141gauron3268",
+			expectNS: "test-ns-deploy",
+			funcFile: `name: test-func
+runtime: go`,
+		},
+		{
+			name:     "ns in func.yaml, not given via cli, current ns matches func.yaml",
+			registry: "docker.io/4141gauron3268",
+			expectNS: "test-ns-deploy",
+			funcFile: `name: test-func
+namespace: "test-ns-deploy"
+runtime: go`,
+		},
+		{
+			name:      "ns in func.yaml, given via cli (always override)",
+			namespace: "test-ns-deploy",
+			expectNS:  "test-ns-deploy",
+			registry:  "docker.io/4141gauron3268",
+			funcFile: `name: test-func
+namespace: "non-default"
+runtime: go`,
+		},
+		{
+			name:     "ns in func.yaml, not given via cli, current ns does NOT match func.yaml",
+			registry: "docker.io/4141gauron3268",
+			expectNS: "non-default",
+			funcFile: `name: test-func
+namespace: "non-default"
+runtime: go`,
+		},
+	}
+
+	// save current dir to use later when tempdir is set
+	testPath := cwd()
+	for _, tt := range tests {
+
+		t.Run(tt.name, func(t *testing.T) {
+			deployer := mock.NewDeployer()
+			defer Fromtemp(t)()
+			cmd := NewDeployCmd(NewClientFactory(func() *fn.Client {
+				return fn.New(
+					fn.WithDeployer(deployer))
+			}))
+
+			// create mock kubeconfig with set namespace as 'default'
+			defer WithEnvVar(t, "KUBECONFIG", fmt.Sprintf("%s/testdata/kubeconfig_deploy_namespace", testPath))()
+
+			// set namespace argument if given & reset after
+			cmd.SetArgs([]string{}) // Do not use test command args
+			viper.SetDefault("namespace", tt.namespace)
+			viper.SetDefault("registry", tt.registry)
+			defer viper.Reset()
+
+			// set test case's func.yaml
+			if err := os.WriteFile("func.yaml", []byte(tt.funcFile), os.ModePerm); err != nil {
+				t.Fatal(err)
+			}
+
+			ctx := context.TODO()
+
+			_, err := cmd.ExecuteContextC(ctx)
+			if err != nil {
+				t.Fatalf("Got error '%s' but expected success", err)
+			}
+
+			fileFunction, err := fn.NewFunction(".")
+			if err != nil {
+				t.Fatalf("problem creating function: %v", err)
+			}
+
+			if fileFunction.Namespace != tt.expectNS {
+				t.Fatalf("Expected namespace '%s' but function has '%s' namespace", tt.expectNS, fileFunction.Namespace)
+			}
+		})
+	}
+}

--- a/cmd/deploy_test.go
+++ b/cmd/deploy_test.go
@@ -140,7 +140,7 @@ created: 2009-11-10 23:00:00`,
 				t.Fatal(err)
 			}
 
-			ctx := context.TODO()
+			ctx := context.Background()
 
 			_, err := cmd.ExecuteContextC(ctx)
 			if err != nil {
@@ -263,7 +263,7 @@ runtime: go`,
 				t.Fatal(err)
 			}
 
-			ctx := context.TODO()
+			ctx := context.Background()
 
 			_, err := cmd.ExecuteContextC(ctx)
 			if err != nil {
@@ -347,7 +347,7 @@ runtime: go`,
 				t.Fatal(err)
 			}
 
-			ctx := context.TODO()
+			ctx := context.Background()
 
 			_, err := cmd.ExecuteContextC(ctx)
 			if err != nil {

--- a/cmd/testdata/kubeconfig_deploy_namespace
+++ b/cmd/testdata/kubeconfig_deploy_namespace
@@ -1,0 +1,25 @@
+apiVersion: v1
+clusters:
+- cluster:
+    insecure-skip-tls-verify: true
+    server: https://example-cluster.serverless.devcluster.openshift.com:6443
+  name: example-cluster-serverless-devcluster-openshift-com:6443
+contexts:
+- context:
+    cluster: example-cluster-serverless-devcluster-openshift-com:6443
+    namespace: default
+    user: kube:admin/example-cluster-serverless-devcluster-openshift-com:6443
+  name: default/example-cluster-serverless-devcluster-openshift-com:6443/kube:admin
+- context:
+    cluster: example-cluster-serverless-devcluster-openshift-com:6443
+    namespace: test-ns-deploy
+    user: kube:admin/example-cluster-serverless-devcluster-openshift-com:6443
+  name: test-ns-deploy/example-cluster-serverless-devcluster-openshift-com:6443/kube:admin
+current-context: test-ns-deploy/example-cluster-serverless-devcluster-openshift-com:6443/kube:admin
+kind: Config
+preferences: {}
+users:
+- name: kubeadmin
+  user:
+    token: sha256~XXXXexample-test-hash
+


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

# Changes
*changes to `func deploy`*

- store namespace to func.yaml on first deployment (from current namespace)
- if namespace is not specified via CLI and is different from func.yaml print warning explaining this 
(ex: `func.yaml->namespace = default` &&  `oc->namespace = myns` -> print warning where func is deployed)
- if namespace is specified via CLI, assume user knows what hes doing, do nothing

*update*
- add fake KUBECONFIG to all the tests in deploy_test.go
- replace `context.TODO` with `context.Background` in deploy_test.go
- print warning to stderr

Fixes #1084 
