### PR TITLE
fix: add languages command to cmd root

### DIFF
--- a/cmd/languages.go
+++ b/cmd/languages.go
@@ -14,7 +14,7 @@ import (
 func NewLanguagesCmd(newClient ClientFactory) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "languages",
-		Short: "Languages",
+		Short: "List available function language runtimes",
 		Long: `
 NAME
 	{{.Name}} languages - list available language runtimes.
@@ -33,7 +33,7 @@ DESCRIPTION
 
 	To specify a URI of a single, specific repository for which languages
 	should be displayed, use the --repository flag.
-	
+
 	To see templates available for a given language, see the 'templates' command.
 
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -98,6 +98,7 @@ EXAMPLES
 	cmd.AddCommand(NewRunCmd(newClient))
 	cmd.AddCommand(NewCompletionCmd())
 	cmd.AddCommand(NewVersionCmd(config.Version))
+	cmd.AddCommand(NewLanguagesCmd(newClient))
 
 	// Help
 	// Overridden to process the help text as a template and have


### PR DESCRIPTION
This command does not get surfaced to the user without adding it to the root.
Also add a little more information to the short description.

Signed-off-by: Lance Ball <lball@redhat.com>

