### PR TITLE
fix: stop build progress loop when build completes

### DIFF
--- a/client.go
+++ b/client.go
@@ -608,7 +608,8 @@ func ensureRuntimeDir(f Function) error {
 // not contain a populated Image.
 func (c *Client) Build(ctx context.Context, path string) (err error) {
 	c.progressListener.Increment("Building function image")
-
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
 	// If not logging verbosely, the ongoing progress of the build will not
 	// be streaming to stdout, and the lack of activity has been seen to cause
 	// users to prematurely exit due to the sluggishness of pulling large images


### PR DESCRIPTION
This change prevents the incremental build messages that loop while
building from continuing during subsequent deploy phases by providing a
cancelable context to the `printBuildActivity()` function parameters.

Fixes: https://github.com/knative-sandbox/kn-plugin-func/issues/974

Signed-off-by: Lance Ball <lball@redhat.com>

-->
```release-note
Fixes a bug where build output overwrites user-facing credentials prompts.
```
/kind fix