### PR TITLE
test: remove verbose from test invoke create/deploy commands

### DIFF
--- a/test/_e2e/cmd_invoke_test.go
+++ b/test/_e2e/cmd_invoke_test.go
@@ -57,9 +57,9 @@ func TestInvoke(t *testing.T) {
 	)
 	defer cleanup()
 
-	run(t, bin, prefix, "create", "--verbose=true", "--language=go", "--template=cloudevents", cwd)
+	run(t, bin, prefix, "create", "--language=go", "--template=cloudevents", cwd)
 	set(t, "handle.go", TestInvokeFunctionImpl)
-	run(t, bin, prefix, "deploy", "--verbose=true", "--registry", GetRegistry())
+	run(t, bin, prefix, "deploy", "--registry", GetRegistry())
 	infoOut := run(t, bin, prefix, "info", "--output", "plain")
 	run(t, bin, prefix, "invoke", "--verbose=true", "--content-type=text/plain", "--source=func:set", "--data=TEST")
 


### PR DESCRIPTION
# Changes

:broom: Just removing `--verbose` from `create` and `deploy` commands on `invoke` e2e tests  just to make e2e logs a bit cleaner. Verbose option is kept on `invoke` command since it is the target command being tested

/kind cleanup
