### PR TITLE
feat: deploy Tekton task supports optional `image` parameter

### DIFF
--- a/pipelines/resources/tekton/task/func-deploy/0.1/func-deploy.yaml
+++ b/pipelines/resources/tekton/task/func-deploy/0.1/func-deploy.yaml
@@ -26,5 +26,5 @@ spec:
   - name: func-deploy
     image: "ghcr.io/knative-sandbox/kn-plugin-func/func:latest"
     script: |
-      [[ "$(params.image)" != "" ]] && export FUNC_IMAGE="$(params.image)"
+      export FUNC_IMAGE="$(params.image)"
       func deploy --verbose --build=disabled --push=false --path=$(params.path)

--- a/pipelines/resources/tekton/task/func-deploy/0.1/func-deploy.yaml
+++ b/pipelines/resources/tekton/task/func-deploy/0.1/func-deploy.yaml
@@ -16,17 +16,15 @@ spec:
   - name: path
     description: Path to the function project
     default: ""
+  - name: image
+    description: Container image to be deployed
+    default: ""
   workspaces:
     - name: source
       description: The workspace containing the function project
   steps:
   - name: func-deploy
     image: "ghcr.io/knative-sandbox/kn-plugin-func/func:latest"
-    command: ["func"]
-    args:
-      - "deploy"
-      - "--verbose"
-      - "--build=disabled"
-      - "--push=false"
-      - "--path"
-      - "$(params.path)"
+    script: |
+      [[ "$(params.image)" != "" ]] && export FUNC_IMAGE="$(params.image)"
+      func deploy --verbose --build=disabled --push=false --path=$(params.path)


### PR DESCRIPTION
Signed-off-by: Zbynek Roubalik <zroubalik@gmail.com>

This is required to enable S2I driven on cluster builds.

<!-- Thanks for sending a pull request! -->

# Changes

- :gift: deploy Tekton task supports optional `image` parameter

Relates to #989 