### PR TITLE
fix: use space prefix for deploy output text

### DIFF
--- a/client.go
+++ b/client.go
@@ -699,13 +699,13 @@ func (c *Client) Deploy(ctx context.Context, path string) (err error) {
 	}
 
 	// Deploy a new or Update the previously-deployed function
-	c.progressListener.Increment("Deploying function to the cluster")
+	c.progressListener.Increment("⬆️  Deploying function to the cluster")
 	result, err := c.deployer.Deploy(ctx, f)
 
 	if result.Status == Deployed {
-		c.progressListener.Increment(fmt.Sprintf("Function deployed in namespace %q and exposed at URL: \n%v", result.Namespace, result.URL))
+		c.progressListener.Increment(fmt.Sprintf("✅ Function deployed in namespace %q and exposed at URL: \n   %v", result.Namespace, result.URL))
 	} else if result.Status == Updated {
-		c.progressListener.Increment(fmt.Sprintf("Function updated in namespace %q and exposed at URL: \n%v", result.Namespace, result.URL))
+		c.progressListener.Increment(fmt.Sprintf("✅ Function updated in namespace %q and exposed at URL: \n   %v", result.Namespace, result.URL))
 	}
 
 	return err

--- a/test/_e2e/cmd_deploy_test.go
+++ b/test/_e2e/cmd_deploy_test.go
@@ -32,7 +32,7 @@ func Deploy(t *testing.T, knFunc *TestShellCmdRunner, project *FunctionTestProje
 		t.Fatal("Function was not deployed")
 	}
 
-	urlMatch := regexp.MustCompile("(URL: \nhttp.*)").FindString(cleanStdout)
+	urlMatch := regexp.MustCompile("(URL: \n   http.*)").FindString(cleanStdout)
 	if urlMatch == "" {
 		t.Fatal("URL not returned on output")
 	}

--- a/test/_e2e/cmd_deploy_test.go
+++ b/test/_e2e/cmd_deploy_test.go
@@ -27,7 +27,7 @@ func Deploy(t *testing.T, knFunc *TestShellCmdRunner, project *FunctionTestProje
 	// "Function [deployed|updated] at URL: http://nodefunc.default.192.168.39.188.nip.io"
 	// Here we extract the URL and store on project setting so that can be used later
 	// to validate actual function responsiveness.
-	wasDeployed := regexp.MustCompile("Function [a-z]* in namespace .* at URL: \nhttp.*").MatchString(cleanStdout)
+	wasDeployed := regexp.MustCompile("✅ Function [a-z]* in namespace .* at URL: \n   http.*").MatchString(cleanStdout)
 	if !wasDeployed {
 		t.Fatal("Function was not deployed")
 	}

--- a/test/_e2e/cmd_deploy_test.go
+++ b/test/_e2e/cmd_deploy_test.go
@@ -37,7 +37,7 @@ func Deploy(t *testing.T, knFunc *TestShellCmdRunner, project *FunctionTestProje
 		t.Fatal("URL not returned on output")
 	}
 
-	project.FunctionURL = strings.Split(urlMatch, "\n")[1]
+	project.FunctionURL = strings.TrimSpace(strings.Split(urlMatch, "\n")[1])
 	project.IsDeployed = true
 
 }


### PR DESCRIPTION
- 🐛  change deploy output text so that it is prefixed with a space, lining up with other text output on the left-hand column, and hopefully fixing the problem where the spinner icon overwrites part of the URL for Windows users.

I also added a couple of emoji to make the output a little friendlier.

Fixes: https://github.com/knative-sandbox/kn-plugin-func/issues/1138

Signed-off-by: Lance Ball <lball@redhat.com>
