### PR TITLE
Added binary builds for platforms ppc64le and s390x

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -56,6 +56,14 @@ jobs:
           path: func_linux_arm64
       - uses: actions/upload-artifact@v2
         with:
+          name: Linux Binary (PPC64LE)
+          path: func_linux_ppc64le
+      - uses: actions/upload-artifact@v2
+        with:
+          name: Linux Binary (S390X)
+          path: func_linux_s390x
+      - uses: actions/upload-artifact@v2
+        with:
           name: Windows Binary
           path: func_windows_amd64.exe
   publish-image:

--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,8 @@ BIN_DARWIN_AMD64   ?= $(BIN)_darwin_amd64
 BIN_DARWIN_ARM64   ?= $(BIN)_darwin_arm64
 BIN_LINUX_AMD64   ?= $(BIN)_linux_amd64
 BIN_LINUX_ARM64   ?= $(BIN)_linux_arm64
+BIN_LINUX_PPC64LE ?= $(BIN)_linux_ppc64le
+BIN_LINUX_S390X   ?= $(BIN)_linux_s390x
 BIN_WINDOWS ?= $(BIN)_windows_amd64.exe
 
 # Version
@@ -151,7 +153,7 @@ test-e2e-runtime: ## Run end-to-end lifecycle tests using an available cluster f
 ##@ Release Artifacts
 ######################
 
-cross-platform: darwin-arm64 darwin-amd64 linux-amd64 linux-arm64 windows ## Build all distributable (cross-platform) binaries
+cross-platform: darwin-arm64 darwin-amd64 linux-amd64 linux-arm64 linux-ppc64le linux-s390x windows ## Build all distributable (cross-platform) binaries
 
 darwin-arm64: $(BIN_DARWIN_ARM64) ## Build for mac M1
 
@@ -172,6 +174,16 @@ linux-arm64: $(BIN_LINUX_ARM64) ## Build for Linux arm64
 
 $(BIN_LINUX_ARM64): zz_filesystem_generated.go
 	env CGO_ENABLED=0 GOOS=linux GOARCH=arm64 go build -o $(BIN_LINUX_ARM64) -ldflags $(LDFLAGS) ./cmd/$(BIN)
+
+linux-ppc64le: $(BIN_LINUX_PPC64LE) ## Build for Linux ppc64le
+
+$(BIN_LINUX_PPC64LE): zz_filesystem_generated.go
+	env CGO_ENABLED=0 GOOS=linux GOARCH=ppc64le go build -o $(BIN_LINUX_PPC64LE) -ldflags $(LDFLAGS) ./cmd/$(BIN)
+
+linux-s390x: $(BIN_LINUX_S390X) ## Build for Linux s390x
+
+$(BIN_LINUX_S390X): zz_filesystem_generated.go
+	env CGO_ENABLED=0 GOOS=linux GOARCH=s390x go build -o $(BIN_LINUX_S390X) -ldflags $(LDFLAGS) ./cmd/$(BIN)
 
 windows: $(BIN_WINDOWS) ## Build for Windows
 

--- a/hack/release.sh
+++ b/hack/release.sh
@@ -22,10 +22,10 @@ VALIDATION_TESTS="make test"
 source $(dirname $0)/../vendor/knative.dev/hack/release.sh
 
 function build_release() {
-  echo "🚧 🐧 Building cross platform binaries: Linux 🐧 (amd64), MacOS 🍏, and Windows 🎠"
+  echo "🚧 🐧 Building cross platform binaries: Linux 🐧 (amd64 / arm64 / ppc64le / s390x), MacOS 🍏, and Windows 🎠"
   ETAG=${TAG} make cross-platform
 
-  ARTIFACTS_TO_PUBLISH="func_darwin_amd64 func_darwin_arm64 func_linux_amd64 func_linux_arm64 func_windows_amd64.exe"
+  ARTIFACTS_TO_PUBLISH="func_darwin_amd64 func_darwin_arm64 func_linux_amd64 func_linux_arm64 func_linux_ppc64le func_linux_s390x func_windows_amd64.exe"
   sha256sum ${ARTIFACTS_TO_PUBLISH} > checksums.txt
   ARTIFACTS_TO_PUBLISH="${ARTIFACTS_TO_PUBLISH} checksums.txt"
   echo "🧮     Checksum:"


### PR DESCRIPTION
# Changes

This PR adds the binaries for platforms ppc64le and s390x to the list of release artifacts. Although at this point function support on these platforms is limited (thanks to paketo.io only supporting x86_64) this is the first step in properly suppporting functions on ppc64le and s390x (possibly via the s2i feature).

/kind enhancement
