### PR TITLE
fix link to reference/command.txt

### DIFF
--- a/docs/function-developers/developers_guide.md
+++ b/docs/function-developers/developers_guide.md
@@ -10,7 +10,7 @@ To learn how to work with functions quickly, have a look at the [Getting Started
 
 ## CLI Command Reference
 
-For detailed documentation on the CLI and its commands, please see the [Command reference](../reference/commands.md).
+For detailed documentation on the CLI and its commands, please see the [Command reference](../reference/commands.txt).
 
 ## Function Project Configuration
 

--- a/docs/function-developers/golang.md
+++ b/docs/function-developers/golang.md
@@ -25,7 +25,7 @@ any Go project. For now, we will ignore the `func.yaml` file, and just
 say that it is a configuration file that is used when building your project.
 If you're really interested, check out the [reference doc](func_yaml.md).
 To learn more about the CLI and the details for each supported command, see
-the [CLI Commands document](commands.md#cli-commands).
+the [CLI Commands document](../reference/commands.txt).
 
 ## Running the function locally
 

--- a/docs/function-developers/nodejs.md
+++ b/docs/function-developers/nodejs.md
@@ -26,7 +26,7 @@ any Node.js project. For now, we will ignore the `func.yaml` file, and just
 say that it is a configuration file that is used when building your project.
 If you're really interested, check out the [reference doc](func_yaml.md).
 To learn more about the CLI and the details for each supported command, see
-the [CLI Commands document](commands.md#cli-commands).
+the [CLI Commands document](../reference/commands.txt).
 
 ## Running the function locally
 

--- a/docs/function-developers/python.md
+++ b/docs/function-developers/python.md
@@ -24,7 +24,7 @@ any Python project. For now, we will ignore the `func.yaml` file, and just
 say that it is a configuration file that is used when building your project.
 If you're really interested, check out the [reference doc](func_yaml.md).
 To learn more about the CLI and the details for each supported command, see
-the [CLI Commands document](commands.md#cli-commands).
+the [CLI Commands document](../reference/commands.txt).
 
 ## Running the function locally
 

--- a/docs/function-developers/quarkus.md
+++ b/docs/function-developers/quarkus.md
@@ -38,7 +38,7 @@ any Java Maven project. For now, we will ignore the `func.yaml` file, and just
 say that it is a configuration file that is used when building your project.
 If you're really interested, check out the [reference doc](func_yaml.md).
 To learn more about the CLI and the details for each supported command, see
-the [CLI Commands document](commands.md#cli-commands).
+the [CLI Commands document](../reference/commands.txt).
 
 ## Running the function locally
 

--- a/docs/function-developers/typescript.md
+++ b/docs/function-developers/typescript.md
@@ -29,7 +29,7 @@ any TypeScript project. For now, we will ignore the `func.yaml` file, and just
 say that it is a configuration file used when building your project.
 If you are interested, check out the [reference doc](func_yaml.md).
 To learn more about the CLI and the details for each supported command, see
-the [CLI Commands document](commands.md#cli-commands).
+the [CLI Commands document](../reference/commands.txt).
 
 ## Running the function locally
 


### PR DESCRIPTION
# Changes

- :bug: fix link to docs/reference/command.txt

/kind documentation