### PR TITLE
fix: ensure registry in func.yaml is respected

### DIFF
--- a/cmd/build_test.go
+++ b/cmd/build_test.go
@@ -54,6 +54,40 @@ created: 2021-01-01T00:00:00+00:00
 	}
 }
 
+// TestBuild_registryConfigurationInYaml tests that a build will execute sucessfully
+// when there is no
+func TestBuild_registryConfigurationInYaml(t *testing.T) {
+	var (
+		builder = mock.NewBuilder() // with a mock builder
+	)
+
+	// Run this test in a temporary directory
+	defer Fromtemp(t)()
+	// Write a func.yaml config which does not specify an image
+	// but does specify a registry
+	funcYaml := `name: registrytest
+namespace: ""
+runtime: go
+image: ""
+registry: quay.io/boson/foo
+created: 2021-01-01T00:00:00+00:00
+`
+	if err := ioutil.WriteFile("func.yaml", []byte(funcYaml), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	// Create build command that will use a mock builder.
+	cmd := NewBuildCmd(NewClientFactory(func() *fn.Client {
+		return fn.New(fn.WithBuilder(builder), fn.WithRegistry("quay.io/boson/foo"))
+	}))
+
+	// Execute the command
+	err := cmd.Execute()
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
 func TestBuild_runBuild(t *testing.T) {
 	tests := []struct {
 		name         string

--- a/cmd/build_test.go
+++ b/cmd/build_test.go
@@ -54,8 +54,8 @@ created: 2021-01-01T00:00:00+00:00
 	}
 }
 
-// TestBuild_registryConfigurationInYaml tests that a build will execute sucessfully
-// when there is no
+// TestBuild_registryConfigurationInYaml tests that a build will execute successfully
+// when there is no registry provided on the command line, but one exists in func.yaml
 func TestBuild_registryConfigurationInYaml(t *testing.T) {
 	var (
 		builder = mock.NewBuilder() // with a mock builder


### PR DESCRIPTION
# Changes

:bug: If the user has a value specified in func.yaml for the image registry, that value should be used by the build command, if not otherwise specified as a flag or via the environment.

Fixes: https://github.com/knative-sandbox/kn-plugin-func/issues/1159

Signed-off-by: Lance Ball <lball@redhat.com>

/kind bug

**Release Note**

```release-note
Fixes function builds when a registry exists in func.yaml but an image has not yet been built
```

