### PR TITLE
quarkus test template change to remove package type property

### DIFF
--- a/test/_e2e/update_templates/quarkus/http/src/main/resources/application.properties
+++ b/test/_e2e/update_templates/quarkus/http/src/main/resources/application.properties
@@ -1,7 +1,6 @@
 # Configuration file
 # key = value
 quarkus.funqy.export=function
-quarkus.package.type=legacy-jar
 quarkus.smallrye-health.root-path=/health
 quarkus.smallrye-health.liveness-path=liveness
 quarkus.smallrye-health.readiness-path=readiness


### PR DESCRIPTION
# Changes

:broom: Removing package.type property from quarkus template used on e2e test to align with default quarkus template.

/kind cleanup
