### PR TITLE
fix: in cluster dialer security context is non-privileged

### DIFF
--- a/k8s/dialer.go
+++ b/k8s/dialer.go
@@ -149,6 +149,7 @@ func (c *contextDialer) startDialerPod(ctx context.Context) (err error) {
 						AllowPrivilegeEscalation: new(bool),
 						RunAsNonRoot:             &runAsNonRoot,
 						Capabilities:             &coreV1.Capabilities{Drop: []coreV1.Capability{"ALL"}},
+						SeccompProfile:           &coreV1.SeccompProfile{Type: coreV1.SeccompProfileTypeRuntimeDefault},
 					},
 				},
 			},

--- a/k8s/dialer.go
+++ b/k8s/dialer.go
@@ -23,7 +23,7 @@ import (
 )
 
 const (
-	socatImage = "quay.io/boson/alpine-socat:1.7.4.3-r"
+	socatImage = "quay.io/boson/alpine-socat:1.7.4.3-r1-non-root"
 )
 
 // NewInClusterDialer creates context dialer that will dial TCP connections via POD running in k8s cluster.
@@ -129,6 +129,7 @@ func (c *contextDialer) startDialerPod(ctx context.Context) (err error) {
 		}
 	}()
 
+	runAsNonRoot := true
 	pod := &coreV1.Pod{
 		ObjectMeta: metaV1.ObjectMeta{
 			Name:        c.podName,
@@ -143,6 +144,11 @@ func (c *contextDialer) startDialerPod(ctx context.Context) (err error) {
 					Stdin:     true,
 					StdinOnce: true,
 					Args:      []string{"-u", "-", "OPEN:/dev/null,append"},
+					SecurityContext: &coreV1.SecurityContext{
+						Privileged:               new(bool),
+						AllowPrivilegeEscalation: new(bool),
+						RunAsNonRoot:             &runAsNonRoot,
+					},
 				},
 			},
 			DNSPolicy:     coreV1.DNSClusterFirst,

--- a/k8s/dialer.go
+++ b/k8s/dialer.go
@@ -102,6 +102,7 @@ func (c *contextDialer) startDialerPod(ctx context.Context) (err error) {
 	if err != nil {
 		return
 	}
+	c.restConf.WarningHandler = restclient.NoWarnings{}
 
 	err = setConfigDefaults(c.restConf)
 	if err != nil {

--- a/k8s/dialer.go
+++ b/k8s/dialer.go
@@ -149,7 +149,6 @@ func (c *contextDialer) startDialerPod(ctx context.Context) (err error) {
 						AllowPrivilegeEscalation: new(bool),
 						RunAsNonRoot:             &runAsNonRoot,
 						Capabilities:             &coreV1.Capabilities{Drop: []coreV1.Capability{"ALL"}},
-						SeccompProfile:           &coreV1.SeccompProfile{Type: coreV1.SeccompProfileTypeRuntimeDefault},
 					},
 				},
 			},

--- a/k8s/dialer.go
+++ b/k8s/dialer.go
@@ -148,6 +148,7 @@ func (c *contextDialer) startDialerPod(ctx context.Context) (err error) {
 						Privileged:               new(bool),
 						AllowPrivilegeEscalation: new(bool),
 						RunAsNonRoot:             &runAsNonRoot,
+						Capabilities:             &coreV1.Capabilities{Drop: []coreV1.Capability{"ALL"}},
 					},
 				},
 			},


### PR DESCRIPTION
# Changes

- :bug: In-cluster-dialer pod security context is non-privileged now.