### PR TITLE
chore: use dot as path default rather than absolute path

### DIFF
--- a/cmd/build.go
+++ b/cmd/build.go
@@ -108,7 +108,7 @@ func runBuild(cmd *cobra.Command, _ []string, newClient ClientFactory) (err erro
 
 	// Check if the function has been initialized
 	if !function.Initialized() {
-		return fmt.Errorf("the given path '%v' does not contain an initialized function. Please create one at this path before deploying", config.Path)
+		return fmt.Errorf("'%v' does not contain an initialized function", config.Path)
 	}
 
 	// If a registry name was provided as a command line flag, it should be validated
@@ -232,7 +232,7 @@ type buildConfig struct {
 }
 
 func newBuildConfig() buildConfig {
-	return buildConfig{
+	cfg := buildConfig{
 		Image:        viper.GetString("image"),
 		Path:         viper.GetString("path"),
 		Registry:     viper.GetString("registry"),
@@ -243,6 +243,10 @@ func newBuildConfig() buildConfig {
 		Push:         viper.GetBool("push"),
 		Platform:     viper.GetString("platform"),
 	}
+	if cfg.Path == "." {
+		cfg.Path = cwd()
+	}
+	return cfg
 }
 
 // Prompt the user with value of config members, allowing for interaractive changes.

--- a/cmd/build.go
+++ b/cmd/build.go
@@ -234,7 +234,7 @@ type buildConfig struct {
 func newBuildConfig() buildConfig {
 	cfg := buildConfig{
 		Image:        viper.GetString("image"),
-		Path:         viper.GetString("path"),
+		Path:         getPathFlag(),
 		Registry:     viper.GetString("registry"),
 		Verbose:      viper.GetBool("verbose"), // defined on root
 		Confirm:      viper.GetBool("confirm"),
@@ -242,9 +242,6 @@ func newBuildConfig() buildConfig {
 		BuilderImage: viper.GetString("builder-image"),
 		Push:         viper.GetBool("push"),
 		Platform:     viper.GetString("platform"),
-	}
-	if cfg.Path == "." {
-		cfg.Path = cwd()
 	}
 	return cfg
 }

--- a/cmd/build.go
+++ b/cmd/build.go
@@ -232,7 +232,7 @@ type buildConfig struct {
 }
 
 func newBuildConfig() buildConfig {
-	cfg := buildConfig{
+	return buildConfig{
 		Image:        viper.GetString("image"),
 		Path:         getPathFlag(),
 		Registry:     viper.GetString("registry"),
@@ -243,7 +243,6 @@ func newBuildConfig() buildConfig {
 		Push:         viper.GetBool("push"),
 		Platform:     viper.GetString("platform"),
 	}
-	return cfg
 }
 
 // Prompt the user with value of config members, allowing for interaractive changes.

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -154,10 +154,7 @@ func newConfigCmdConfig(args []string) configCmdConfig {
 	}
 	cfg := configCmdConfig{
 		Name: deriveName(name, viper.GetString("path")),
-		Path: viper.GetString("path"),
-	}
-	if cfg.Path == "." {
-		cfg.Path = cwd()
+		Path: getPathFlag(),
 	}
 	return cfg
 

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -152,11 +152,10 @@ func newConfigCmdConfig(args []string) configCmdConfig {
 	if len(args) > 0 {
 		name = args[0]
 	}
-	cfg := configCmdConfig{
+	return configCmdConfig{
 		Name: deriveName(name, viper.GetString("path")),
 		Path: getPathFlag(),
 	}
-	return cfg
 
 }
 

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -152,10 +152,14 @@ func newConfigCmdConfig(args []string) configCmdConfig {
 	if len(args) > 0 {
 		name = args[0]
 	}
-	return configCmdConfig{
+	cfg := configCmdConfig{
 		Name: deriveName(name, viper.GetString("path")),
 		Path: viper.GetString("path"),
 	}
+	if cfg.Path == "." {
+		cfg.Path = cwd()
+	}
+	return cfg
 
 }
 

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/AlecAivazis/survey/v2"
 	"github.com/AlecAivazis/survey/v2/terminal"
-	"github.com/ory/viper"
 	"github.com/spf13/cobra"
 
 	fn "knative.dev/kn-plugin-func"
@@ -153,7 +152,7 @@ func newConfigCmdConfig(args []string) configCmdConfig {
 		name = args[0]
 	}
 	return configCmdConfig{
-		Name: deriveName(name, viper.GetString("path")),
+		Name: deriveName(name, getPathFlag()),
 		Path: getPathFlag(),
 	}
 

--- a/cmd/delete.go
+++ b/cmd/delete.go
@@ -109,13 +109,17 @@ func newDeleteConfig(args []string) deleteConfig {
 	if len(args) > 0 {
 		name = args[0]
 	}
-	return deleteConfig{
+	cfg := deleteConfig{
 		Path:      viper.GetString("path"),
 		Namespace: viper.GetString("namespace"),
 		DeleteAll: viper.GetBool("all"),
 		Name:      deriveName(name, viper.GetString("path")), // args[0] or derived
 		Verbose:   viper.GetBool("verbose"),                  // defined on root
 	}
+	if cfg.Path == "." {
+		cfg.Path = cwd()
+	}
+	return cfg
 }
 
 // Prompt the user with value of config members, allowing for interaractive changes.

--- a/cmd/delete.go
+++ b/cmd/delete.go
@@ -109,14 +109,13 @@ func newDeleteConfig(args []string) deleteConfig {
 	if len(args) > 0 {
 		name = args[0]
 	}
-	cfg := deleteConfig{
+	return deleteConfig{
 		Path:      getPathFlag(),
 		Namespace: viper.GetString("namespace"),
 		DeleteAll: viper.GetBool("all"),
 		Name:      deriveName(name, viper.GetString("path")), // args[0] or derived
 		Verbose:   viper.GetBool("verbose"),                  // defined on root
 	}
-	return cfg
 }
 
 // Prompt the user with value of config members, allowing for interaractive changes.

--- a/cmd/delete.go
+++ b/cmd/delete.go
@@ -110,14 +110,11 @@ func newDeleteConfig(args []string) deleteConfig {
 		name = args[0]
 	}
 	cfg := deleteConfig{
-		Path:      viper.GetString("path"),
+		Path:      getPathFlag(),
 		Namespace: viper.GetString("namespace"),
 		DeleteAll: viper.GetBool("all"),
 		Name:      deriveName(name, viper.GetString("path")), // args[0] or derived
 		Verbose:   viper.GetBool("verbose"),                  // defined on root
-	}
-	if cfg.Path == "." {
-		cfg.Path = cwd()
 	}
 	return cfg
 }

--- a/cmd/delete.go
+++ b/cmd/delete.go
@@ -113,8 +113,8 @@ func newDeleteConfig(args []string) deleteConfig {
 		Path:      getPathFlag(),
 		Namespace: viper.GetString("namespace"),
 		DeleteAll: viper.GetBool("all"),
-		Name:      deriveName(name, viper.GetString("path")), // args[0] or derived
-		Verbose:   viper.GetBool("verbose"),                  // defined on root
+		Name:      deriveName(name, getPathFlag()), // args[0] or derived
+		Verbose:   viper.GetBool("verbose"),        // defined on root
 	}
 }
 

--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -446,7 +446,7 @@ func newDeployConfig(cmd *cobra.Command) (deployConfig, error) {
 		buildType = viper.GetString("build")
 	}
 
-	cfg := deployConfig{
+	return deployConfig{
 		buildConfig: newBuildConfig(),
 		Namespace:   viper.GetString("namespace"),
 		Path:        getPathFlag(),
@@ -459,8 +459,7 @@ func newDeployConfig(cmd *cobra.Command) (deployConfig, error) {
 		GitURL:      viper.GetString("git-url"),
 		GitBranch:   viper.GetString("git-branch"),
 		GitDir:      viper.GetString("git-dir"),
-	}
-	return cfg, nil
+	}, nil
 }
 
 // Prompt the user with value of config members, allowing for interaractive changes.

--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -446,7 +446,7 @@ func newDeployConfig(cmd *cobra.Command) (deployConfig, error) {
 		buildType = viper.GetString("build")
 	}
 
-	return deployConfig{
+	cfg := deployConfig{
 		buildConfig: newBuildConfig(),
 		Namespace:   viper.GetString("namespace"),
 		Path:        viper.GetString("path"),
@@ -459,7 +459,11 @@ func newDeployConfig(cmd *cobra.Command) (deployConfig, error) {
 		GitURL:      viper.GetString("git-url"),
 		GitBranch:   viper.GetString("git-branch"),
 		GitDir:      viper.GetString("git-dir"),
-	}, nil
+	}
+	if cfg.Path == "." {
+		cfg.Path = cwd()
+	}
+	return cfg, nil
 }
 
 // Prompt the user with value of config members, allowing for interaractive changes.

--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -449,7 +449,7 @@ func newDeployConfig(cmd *cobra.Command) (deployConfig, error) {
 	cfg := deployConfig{
 		buildConfig: newBuildConfig(),
 		Namespace:   viper.GetString("namespace"),
-		Path:        viper.GetString("path"),
+		Path:        getPathFlag(),
 		Verbose:     viper.GetBool("verbose"), // defined on root
 		Confirm:     viper.GetBool("confirm"),
 		BuildType:   buildType,
@@ -459,9 +459,6 @@ func newDeployConfig(cmd *cobra.Command) (deployConfig, error) {
 		GitURL:      viper.GetString("git-url"),
 		GitBranch:   viper.GetString("git-branch"),
 		GitDir:      viper.GetString("git-dir"),
-	}
-	if cfg.Path == "." {
-		cfg.Path = cwd()
 	}
 	return cfg, nil
 }

--- a/cmd/format.go
+++ b/cmd/format.go
@@ -3,7 +3,6 @@ package cmd
 import (
 	"fmt"
 	"io"
-	"os"
 )
 
 type Format string
@@ -48,7 +47,6 @@ func write(out io.Writer, s Formatter, formatName string) {
 		err = fmt.Errorf("format not recognized: %v\n", formatName)
 	}
 	if err != nil {
-		fmt.Fprintln(os.Stderr, err)
-		os.Exit(2)
+		panic(err)
 	}
 }

--- a/cmd/info.go
+++ b/cmd/info.go
@@ -95,14 +95,13 @@ func newInfoConfig(args []string) infoConfig {
 	if len(args) > 0 {
 		name = args[0]
 	}
-	cfg := infoConfig{
+	return infoConfig{
 		Name:      deriveName(name, viper.GetString("path")),
 		Namespace: viper.GetString("namespace"),
 		Output:    viper.GetString("output"),
 		Path:      getPathFlag(),
 		Verbose:   viper.GetBool("verbose"),
 	}
-	return cfg
 }
 
 // Output Formatting (serializers)

--- a/cmd/info.go
+++ b/cmd/info.go
@@ -99,11 +99,8 @@ func newInfoConfig(args []string) infoConfig {
 		Name:      deriveName(name, viper.GetString("path")),
 		Namespace: viper.GetString("namespace"),
 		Output:    viper.GetString("output"),
-		Path:      viper.GetString("path"),
+		Path:      getPathFlag(),
 		Verbose:   viper.GetBool("verbose"),
-	}
-	if cfg.Path == "." {
-		cfg.Path = cwd()
 	}
 	return cfg
 }

--- a/cmd/info.go
+++ b/cmd/info.go
@@ -96,7 +96,7 @@ func newInfoConfig(args []string) infoConfig {
 		name = args[0]
 	}
 	return infoConfig{
-		Name:      deriveName(name, viper.GetString("path")),
+		Name:      deriveName(name, getPathFlag()),
 		Namespace: viper.GetString("namespace"),
 		Output:    viper.GetString("output"),
 		Path:      getPathFlag(),

--- a/cmd/info.go
+++ b/cmd/info.go
@@ -95,13 +95,17 @@ func newInfoConfig(args []string) infoConfig {
 	if len(args) > 0 {
 		name = args[0]
 	}
-	return infoConfig{
+	cfg := infoConfig{
 		Name:      deriveName(name, viper.GetString("path")),
 		Namespace: viper.GetString("namespace"),
 		Output:    viper.GetString("output"),
 		Path:      viper.GetString("path"),
 		Verbose:   viper.GetBool("verbose"),
 	}
+	if cfg.Path == "." {
+		cfg.Path = cwd()
+	}
+	return cfg
 }
 
 // Output Formatting (serializers)

--- a/cmd/invoke.go
+++ b/cmd/invoke.go
@@ -103,7 +103,7 @@ EXAMPLES
 	}
 
 	// Flags
-	cmd.Flags().StringP("path", "p", cwd(), "Path to the function which should have its instance invoked. (Env: $FUNC_PATH)")
+	cmd.Flags().StringP("path", "p", ".", "Path to the function which should have its instance invoked. (Env: $FUNC_PATH)")
 	cmd.Flags().StringP("format", "f", "", "Format of message to send, 'http' or 'cloudevent'.  Default is to choose automatically. (Env: $FUNC_FORMAT)")
 	cmd.Flags().StringP("target", "t", "", "Function instance to invoke.  Can be 'local', 'remote' or a URL.  Defaults to auto-discovery if not provided. (Env: $FUNC_TARGET)")
 	cmd.Flags().StringP("id", "", "", "ID for the request data. (Env: $FUNC_ID)")
@@ -217,6 +217,11 @@ func newInvokeConfig(newClient ClientFactory) (cfg invokeConfig, err error) {
 		Confirm:     viper.GetBool("confirm"),
 		Verbose:     viper.GetBool("verbose"),
 		Namespace:   viper.GetString("namespace"),
+	}
+
+	// If path is ".", convert to absolute path
+	if cfg.Path == "." {
+		cfg.Path = cwd()
 	}
 
 	// If file was passed, read it in as data

--- a/cmd/invoke.go
+++ b/cmd/invoke.go
@@ -103,7 +103,7 @@ EXAMPLES
 	}
 
 	// Flags
-	cmd.Flags().StringP("path", "p", ".", "Path to the function which should have its instance invoked. (Env: $FUNC_PATH)")
+	setPathFlag(cmd)
 	cmd.Flags().StringP("format", "f", "", "Format of message to send, 'http' or 'cloudevent'.  Default is to choose automatically. (Env: $FUNC_FORMAT)")
 	cmd.Flags().StringP("target", "t", "", "Function instance to invoke.  Can be 'local', 'remote' or a URL.  Defaults to auto-discovery if not provided. (Env: $FUNC_TARGET)")
 	cmd.Flags().StringP("id", "", "", "ID for the request data. (Env: $FUNC_ID)")
@@ -205,7 +205,7 @@ type invokeConfig struct {
 
 func newInvokeConfig(newClient ClientFactory) (cfg invokeConfig, err error) {
 	cfg = invokeConfig{
-		Path:        viper.GetString("path"),
+		Path:        getPathFlag(),
 		Target:      viper.GetString("target"),
 		Format:      viper.GetString("format"),
 		ID:          viper.GetString("id"),
@@ -217,11 +217,6 @@ func newInvokeConfig(newClient ClientFactory) (cfg invokeConfig, err error) {
 		Confirm:     viper.GetBool("confirm"),
 		Verbose:     viper.GetBool("verbose"),
 		Namespace:   viper.GetString("namespace"),
-	}
-
-	// If path is ".", convert to absolute path
-	if cfg.Path == "." {
-		cfg.Path = cwd()
 	}
 
 	// If file was passed, read it in as data

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -335,7 +335,7 @@ func mergeEnvs(envs []fn.Env, envToUpdate *util.OrderedMap, envToRemove []string
 
 // setPathFlag ensures common text/wording when the --path flag is used
 func setPathFlag(cmd *cobra.Command) {
-	cmd.Flags().StringP("path", "p", cwd(), "Path to the project directory (Env: $FUNC_PATH)")
+	cmd.Flags().StringP("path", "p", ".", "Path to the project directory (Env: $FUNC_PATH)")
 }
 
 type Version struct {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -144,16 +144,6 @@ func interactiveTerminal() bool {
 	return err == nil && ((fi.Mode() & os.ModeCharDevice) != 0)
 }
 
-// cwd returns the current working directory or exits 1 printing the error.
-func cwd() (cwd string) {
-	cwd, err := os.Getwd()
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "Unable to determine current working directory: %v", err)
-		os.Exit(1)
-	}
-	return cwd
-}
-
 // bindFunc which conforms to the cobra PreRunE method signature
 type bindFunc func(*cobra.Command, []string) error
 
@@ -336,6 +326,27 @@ func mergeEnvs(envs []fn.Env, envToUpdate *util.OrderedMap, envToRemove []string
 // setPathFlag ensures common text/wording when the --path flag is used
 func setPathFlag(cmd *cobra.Command) {
 	cmd.Flags().StringP("path", "p", ".", "Path to the project directory (Env: $FUNC_PATH)")
+}
+
+// getPathFlag returns the value of the --path flag.
+// The special value '.' is returned as the abolute path to the current
+// working directory.
+func getPathFlag() string {
+	path := viper.GetString("path")
+	if path == "." {
+		path = cwd()
+	}
+	return path
+}
+
+// cwd returns the current working directory or exits 1 printing the error.
+func cwd() (cwd string) {
+	cwd, err := os.Getwd()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Unable to determine current working directory: %v", err)
+		os.Exit(1)
+	}
+	return cwd
 }
 
 type Version struct {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -343,8 +343,7 @@ func getPathFlag() string {
 func cwd() (cwd string) {
 	cwd, err := os.Getwd()
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "Unable to determine current working directory: %v", err)
-		os.Exit(1)
+		panic(fmt.Sprintf("Unable to determine current working directory: %v", err))
 	}
 	return cwd
 }

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -168,18 +168,21 @@ type runConfig struct {
 	Registry string
 }
 
-func newRunConfig(cmd *cobra.Command) (c runConfig, err error) {
+func newRunConfig(cmd *cobra.Command) (cfg runConfig, err error) {
 	envToUpdate, envToRemove, err := envFromCmd(cmd)
 	if err != nil {
 		return
 	}
-
-	return runConfig{
+	cfg = runConfig{
 		Build:       viper.GetString("build"),
 		Path:        viper.GetString("path"),
 		Verbose:     viper.GetBool("verbose"), // defined on root
 		Registry:    viper.GetString("registry"),
 		EnvToUpdate: envToUpdate,
 		EnvToRemove: envToRemove,
-	}, nil
+	}
+	if cfg.Path == "." {
+		cfg.Path = cwd()
+	}
+	return
 }

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -181,8 +181,5 @@ func newRunConfig(cmd *cobra.Command) (cfg runConfig, err error) {
 		EnvToUpdate: envToUpdate,
 		EnvToRemove: envToRemove,
 	}
-	if cfg.Path == "." {
-		cfg.Path = cwd()
-	}
 	return
 }

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -175,7 +175,7 @@ func newRunConfig(cmd *cobra.Command) (cfg runConfig, err error) {
 	}
 	cfg = runConfig{
 		Build:       viper.GetString("build"),
-		Path:        viper.GetString("path"),
+		Path:        getPathFlag(),
 		Verbose:     viper.GetBool("verbose"), // defined on root
 		Registry:    viper.GetString("registry"),
 		EnvToUpdate: envToUpdate,

--- a/docs/reference/commands.txt
+++ b/docs/reference/commands.txt
@@ -6,24 +6,24 @@ CREATE
 
 
 NAME
-	func create - Create a Function project.
+	func create - Create a function project.
 
 SYNOPSIS
 	func create [-l|--language] [-t|--template] [-r|--repository]
 	            [-c|--confirm]  [-v|--verbose]  [path]
 
 DESCRIPTION
-	Creates a new Function project.
+	Creates a new function project.
 
 	  $ func create -l node -t http
 
-	Creates a Function in the current directory '.' which is written in the
+	Creates a function in the current directory '.' which is written in the
 	language/runtime 'node' and handles HTTP events.
 
-	If [path] is provided, the Function is initialized at that path, creating
+	If [path] is provided, the function is initialized at that path, creating
 	the path if necessary.
 
-	To complete this command interactivly, use --confirm (-c):
+	To complete this command interactively, use --confirm (-c):
 	  $ func create -c
 
 	Available Language Runtimes and Templates:
@@ -31,12 +31,14 @@ DESCRIPTION
 	  --------     --------
 	  go           cloudevents
 	  go           http
+	  go           lkingland/e2e
 	  node         cloudevents
 	  node         http
 	  python       cloudevents
 	  python       http
 	  quarkus      cloudevents
 	  quarkus      http
+	  runtime      lkingland/template
 	  rust         cloudevents
 	  rust         http
 	  springboot   cloudevents
@@ -49,15 +51,15 @@ DESCRIPTION
 
 
 EXAMPLES
-	o Create a Node.js Function (the default language runtime) in the current
+	o Create a Node.js function (the default language runtime) in the current
 	  directory (the default path) which handles http events (the default
 	  template).
 	  $ func create
 
-	o Create a Node.js Function in the directory 'myfunc'.
+	o Create a Node.js function in the directory 'myfunc'.
 	  $ func create myfunc
 
-	o Create a Go Function which handles CloudEvents in ./myfunc.
+	o Create a Go function which handles CloudEvents in ./myfunc.
 	  $ func create -l go -t cloudevents myfunc
 		
 
@@ -83,8 +85,8 @@ Build a function project as a container image
 
 This command builds the function project in the current directory or in the directory
 specified by --path. The result will be a container image that is pushed to a registry.
-The func.yaml file is read to determine the image name and registry. 
-If the project has not already been built, either --registry or --image must be provided 
+The func.yaml file is read to determine the image name and registry.
+If the project has not already been built, either --registry or --image must be provided
 and the image name is stored in the configuration file.
 
 
@@ -112,13 +114,13 @@ func build --builder=pack --builder-image cnbs/sample-builder:bionic
 
 
 Flags:
-  -b, --builder string         build strategy to use when creating the underlying image. Currently supported build strategies are 'pack' and 's2i'. (default "pack")
+  -b, --builder string         build strategy to use when creating the underlying image. Currently supported build strategies are "pack" or "s2i". (default "pack")
       --builder-image string   builder image, either an as a an image name or a mapping name.
                                Specified value is stored in func.yaml (as 'builder' field) for subsequent builds. ($FUNC_BUILDER_IMAGE)
   -c, --confirm                Prompt to confirm all configuration options (Env: $FUNC_CONFIRM)
   -h, --help                   help for build
   -i, --image string           Full image name in the form [registry]/[namespace]/[name]:[tag] (optional). This option takes precedence over --registry (Env: $FUNC_IMAGE)
-  -p, --path string            Path to the project directory (Env: $FUNC_PATH) (default "/Users/lball/src/github.com/knative-sandbox/kn-plugin-func")
+  -p, --path string            Path to the project directory (Env: $FUNC_PATH) (default ".")
       --platform string        Target platform to build (e.g. linux/amd64).
   -u, --push                   Attempt to push the function image after being successfully built
   -r, --registry string        Registry + namespace part of the image to build, ex 'quay.io/myuser'.  The full image name is automatically determined based on the local directory name. If not provided the registry will be taken from func.yaml (Env: $FUNC_REGISTRY)
@@ -133,7 +135,7 @@ CONFIG
 
 Configure a function
 
-Interactive propmt that allows configuration of Volume mounts, Environment
+Interactive prompt that allows configuration of Volume mounts, Environment
 variables, and Labels for a function project present in the current directory
 or from the directory specified with --path.
 
@@ -149,7 +151,7 @@ Available Commands:
 
 Flags:
   -h, --help          help for config
-  -p, --path string   Path to the project directory (Env: $FUNC_PATH) (default "/Users/lball/src/github.com/knative-sandbox/kn-plugin-func")
+  -p, --path string   Path to the project directory (Env: $FUNC_PATH) (default ".")
 
 Global Flags:
   -n, --namespace string   The namespace on the cluster used for remote commands. By default, the namespace func.yaml is used or the currently active namespace if not set in the configuration. (Env: $FUNC_NAMESPACE)
@@ -163,24 +165,24 @@ CREATE
 
 
 NAME
-	func create - Create a Function project.
+	func create - Create a function project.
 
 SYNOPSIS
 	func create [-l|--language] [-t|--template] [-r|--repository]
 	            [-c|--confirm]  [-v|--verbose]  [path]
 
 DESCRIPTION
-	Creates a new Function project.
+	Creates a new function project.
 
 	  $ func create -l node -t http
 
-	Creates a Function in the current directory '.' which is written in the
+	Creates a function in the current directory '.' which is written in the
 	language/runtime 'node' and handles HTTP events.
 
-	If [path] is provided, the Function is initialized at that path, creating
+	If [path] is provided, the function is initialized at that path, creating
 	the path if necessary.
 
-	To complete this command interactivly, use --confirm (-c):
+	To complete this command interactively, use --confirm (-c):
 	  $ func create -c
 
 	Available Language Runtimes and Templates:
@@ -188,12 +190,14 @@ DESCRIPTION
 	  --------     --------
 	  go           cloudevents
 	  go           http
+	  go           lkingland/e2e
 	  node         cloudevents
 	  node         http
 	  python       cloudevents
 	  python       http
 	  quarkus      cloudevents
 	  quarkus      http
+	  runtime      lkingland/template
 	  rust         cloudevents
 	  rust         http
 	  springboot   cloudevents
@@ -206,15 +210,15 @@ DESCRIPTION
 
 
 EXAMPLES
-	o Create a Node.js Function (the default language runtime) in the current
+	o Create a Node.js function (the default language runtime) in the current
 	  directory (the default path) which handles http events (the default
 	  template).
 	  $ func create
 
-	o Create a Node.js Function in the directory 'myfunc'.
+	o Create a Node.js function in the directory 'myfunc'.
 	  $ func create myfunc
 
-	o Create a Go Function which handles CloudEvents in ./myfunc.
+	o Create a Go function which handles CloudEvents in ./myfunc.
 	  $ func create -l go -t cloudevents myfunc
 		
 
@@ -261,7 +265,7 @@ Flags:
   -a, --all string    Delete all resources created for a function, eg. Pipelines, Secrets, etc. (Env: $FUNC_ALL) (allowed values: "true", "false") (default "true")
   -c, --confirm       Prompt to confirm all configuration options (Env: $FUNC_CONFIRM)
   -h, --help          help for delete
-  -p, --path string   Path to the project directory (Env: $FUNC_PATH) (default "/Users/lball/src/github.com/knative-sandbox/kn-plugin-func")
+  -p, --path string   Path to the project directory (Env: $FUNC_PATH) (default ".")
 
 Global Flags:
   -n, --namespace string   The namespace on the cluster used for remote commands. By default, the namespace func.yaml is used or the currently active namespace if not set in the configuration. (Env: $FUNC_NAMESPACE)
@@ -300,7 +304,7 @@ func deploy --image quay.io/myuser/myfunc -n myns
 
 Flags:
   -b, --build string           Build specifies the way the function should be built. Supported types are "disabled", "local" or "git" (Env: $FUNC_BUILD) (default "local")
-      --builder string         build strategy to use when creating the underlying image. Currently supported build strategies are 'pack' and 's2i'. (default "pack")
+      --builder string         build strategy to use when creating the underlying image. Currently supported build strategies are "pack" or "s2i". (default "pack")
       --builder-image string   builder image, either an as a an image name or a mapping name.
                                Specified value is stored in func.yaml (as 'builder' field) for subsequent builds. ($FUNC_BUILDER_IMAGE)
   -c, --confirm                Prompt to confirm all configuration options (Env: $FUNC_CONFIRM)
@@ -309,8 +313,8 @@ Flags:
   -d, --git-dir string         Directory in the repo where the function is located (Env: $FUNC_GIT_DIR)
   -g, --git-url string         Repo url to push the code to be built (Env: $FUNC_GIT_URL)
   -h, --help                   help for deploy
-  -i, --image string           Full image name in the form [registry]/[namespace]/[name]:[tag] (optional). This option takes precedence over --registry (Env: $FUNC_IMAGE)
-  -p, --path string            Path to the project directory (Env: $FUNC_PATH) (default "/Users/lball/src/github.com/knative-sandbox/kn-plugin-func")
+  -i, --image string           Full image name in the form [registry]/[namespace]/[name]:[tag]@[digest]. This option takes precedence over --registry. Specifying digest is optional, but if it is given, 'build' and 'push' phases are disabled. (Env: $FUNC_IMAGE)
+  -p, --path string            Path to the project directory (Env: $FUNC_PATH) (default ".")
       --platform string        Target platform to build (e.g. linux/amd64).
   -u, --push                   Attempt to push the function image to registry before deploying (Env: $FUNC_PUSH) (default true)
   -r, --registry string        Registry + namespace part of the image to build, ex 'quay.io/myuser'.  The full image name is automatically determined based on the local directory name. If not provided the registry will be taken from func.yaml (Env: $FUNC_REGISTRY)
@@ -344,7 +348,7 @@ func info --output yaml --path myotherfunc
 Flags:
   -h, --help            help for info
   -o, --output string   Output format (human|plain|json|xml|yaml|url) (Env: $FUNC_OUTPUT) (default "human")
-  -p, --path string     Path to the project directory (Env: $FUNC_PATH) (default "/Users/lball/src/github.com/knative-sandbox/kn-plugin-func")
+  -p, --path string     Path to the project directory (Env: $FUNC_PATH) (default ".")
 
 Global Flags:
   -n, --namespace string   The namespace on the cluster used for remote commands. By default, the namespace func.yaml is used or the currently active namespace if not set in the configuration. (Env: $FUNC_NAMESPACE)
@@ -356,7 +360,7 @@ INVOKE
 
 
 NAME
-	func invoke - Invoke a Function.
+	func invoke - test a function by invoking it with test data
 
 SYNOPSIS
 	func invoke [-t|--target] [-f|--format]
@@ -364,8 +368,8 @@ SYNOPSIS
 	             [-s|--save] [-p|--path] [-c|--confirm] [-v|--verbose]
 
 DESCRIPTION
-	Invokes the Function by sending a test request to the currently running
-	Function instance, either locally or remote.  If the Function is running
+	Invokes the function by sending a test request to the currently running
+	function instance, either locally or remote.  If the function is running
 	both locally and remote, the local instance will be invoked.  This behavior
 	can be manually overridden using the --target flag.
 
@@ -381,49 +385,49 @@ DESCRIPTION
 	--file flag.
 
 	Invocation Target
-	  The Function instance to invoke can be specified using the --target flag
+	  The function instance to invoke can be specified using the --target flag
 	  which accepts the values "local", "remote", or <URL>.  By default the
-	  local Function instance is chosen if running (see func run).
-	  To explicitly target the remote (deployed) Function:
+	  local function instance is chosen if running (see func run).
+	  To explicitly target the remote (deployed) function:
 	    func invoke --target=remote
 	  To target an arbitrary endpoint, provide a URL:
 	    func invoke --target=https://myfunction.example.com
 
 	Invocation Data
 	  Providing a filename in the --file flag will base64 encode its contents
-	  as the "data" parameter sent to the Function.  The value of --content-type
+	  as the "data" parameter sent to the function.  The value of --content-type
 	  should be set to the type from the source file.  For example, the following
 	  would send a JPEG base64 encoded in the "data" POST parameter:
 	    func invoke --file=example.jpeg --content-type=image/jpeg
 
 	Message Format
-	  By default Functions are sent messages which match the invocation format
+	  By default functions are sent messages which match the invocation format
 	  of the template they were created using; for example "http" or "cloudevent".
 	  To override this behavior, use the --format (-f) flag.
 	    func invoke -f=cloudevent -t=http://my-sink.my-cluster
 
 EXAMPLES
 
-	o Invoke the default (local or remote) running Function with default values
+	o Invoke the default (local or remote) running function with default values
 	  $ func invoke
 
-	o Run the Function locally and then invoke it with a test request:
+	o Run the function locally and then invoke it with a test request:
 	  (run in two terminals or by running the first in the background)
 	  $ func run
 	  $ func invoke
 
-	o Deploy and then invoke the remote Function:
+	o Deploy and then invoke the remote function:
 	  $ func deploy
 	  $ func invoke
 
-	o Invoke a remote (deployed) Function when it is already running locally:
+	o Invoke a remote (deployed) function when it is already running locally:
 	  (overrides the default behavior of preferring locally running instances)
 	  $ func invoke --target=remote
 
-	o Specify the data to send to the Function as a flag
+	o Specify the data to send to the function as a flag
 	  $ func invoke --data="Hello World!"
 
-	o Send a JPEG to the Function
+	o Send a JPEG to the function
 	  $ func invoke --file=example.jpeg --content-type=image/jpeg
 
 	o Invoke an arbitrary endpoint (HTTP POST)
@@ -445,7 +449,7 @@ Flags:
   -f, --format string         Format of message to send, 'http' or 'cloudevent'.  Default is to choose automatically. (Env: $FUNC_FORMAT)
   -h, --help                  help for invoke
       --id string             ID for the request data. (Env: $FUNC_ID)
-  -p, --path string           Path to the Function which should have its instance invoked. (Env: $FUNC_PATH) (default "/Users/lball/src/github.com/knative-sandbox/kn-plugin-func")
+  -p, --path string           Path to the function which should have its instance invoked. (Env: $FUNC_PATH) (default ".")
       --source string         Source value for the request data. (Env: $FUNC_SOURCE) (default "/boson/fn")
   -t, --target string         Function instance to invoke.  Can be 'local', 'remote' or a URL.  Defaults to auto-discovery if not provided. (Env: $FUNC_TARGET)
       --type string           Type value for the request data. (Env: $FUNC_TYPE) (default "boson.fn")
@@ -506,7 +510,7 @@ DESCRIPTION
 	Manage template repositories installed on disk at either the default location
 	(~/.config/func/repositories) or the location specified by the --repository
 	flag.  Once added, a template from the repository can be used when creating
-	a new Function.
+	a new function.
 
 	Interactive Prompts:
 	To complete these commands interactively, pass the --confirm (-c) flag to
@@ -515,7 +519,7 @@ DESCRIPTION
 	The Default Repository:
 	The default repository is not stored on disk, but embedded in the binary and
 	can be used without explicitly specifying the name.  The default repository
-	is always listed first, and is assumed when creating a new Function without
+	is always listed first, and is assumed when creating a new function without
 	specifying a repository name prefix.
 	For example, to create a new Go function using the 'http' template from the
 	default repository.
@@ -524,7 +528,7 @@ DESCRIPTION
 	The Repository Flag:
 	Installing repositories locally is optional.  To use a template from a remote
 	repository directly, it is possible to use the --repository flag on create.
-	This leaves the local disk untouched.  For example, To create a Function using
+	This leaves the local disk untouched.  For example, To create a function using
 	the Boson Project Hello-World template without installing the template
 	repository locally, use the --repository (-r) flag on create:
 		$ func create -l go \
@@ -550,9 +554,9 @@ COMMANDS
 	  For Example, to add the Boson Project repository:
 	    $ func repository add boson https://github.com/boson-project/templates
 
-	  Once added, a Function can be created with templates from the new repository
+	  Once added, a function can be created with templates from the new repository
 	  by prefixing the template name with the repository.  For example, to create
-	  a new Function using the Go Hello World template:
+	  a new function using the Go Hello World template:
 	    $ func create -l go -t boson/hello-world
 
 	list
@@ -577,7 +581,7 @@ EXAMPLES
 	o Run in confirmation mode (interactive prompts) using the --confirm flag
 	  $ func repository -c
 
-	o Add a repository and create a new Function using a template from it:
+	o Add a repository and create a new function using a template from it:
 	  $ func repository add boson https://github.com/boson-project/templates
 	  $ func repository list
 	  default
@@ -641,8 +645,8 @@ Runs the function locally in the current directory or in the directory
 specified by --path flag.
 
 Building
-By default the Function will be built if never built, or if changes are detected
-to the Function's source.  Use --build to override this behavior.
+By default the function will be built if never built, or if changes are detected
+to the function's source.  Use --build to override this behavior.
 
 
 
@@ -651,15 +655,15 @@ Usage:
 
 Examples:
 
-# Run the Function locally, building if necessary
+# Run the function locally, building if necessary
 func run
 
-# Run the Function, forcing a rebuild of the image.
-#   This is useful when the Function's image was manually deleted, necessitating
-#   A rebuild even when no changes have been made the Function's source.
+# Run the function, forcing a rebuild of the image.
+#   This is useful when the function's image was manually deleted, necessitating
+#   A rebuild even when no changes have been made the function's source.
 func run --build
 
-# Run the Function's existing image, disabling auto-build.
+# Run the function's existing image, disabling auto-build.
 #   This is useful when filesystem changes have been made, but one wishes to
 #   run the previously built image without rebuilding.
 func run --build=false
@@ -670,7 +674,7 @@ Flags:
   -b, --build string[="true"]   Build the function. [auto|true|false]. (default "auto")
   -e, --env stringArray         Environment variable to set in the form NAME=VALUE. You may provide this flag multiple times for setting multiple environment variables. To unset, specify the environment variable name followed by a "-" (e.g., NAME-).
   -h, --help                    help for run
-  -p, --path string             Path to the project directory (Env: $FUNC_PATH) (default "/Users/lball/src/github.com/knative-sandbox/kn-plugin-func")
+  -p, --path string             Path to the project directory (Env: $FUNC_PATH) (default ".")
   -r, --registry string         Registry + namespace part of the image if building, ex 'quay.io/myuser' (Env: $FUNC_REGISTRY)
 
 Global Flags:


### PR DESCRIPTION
:broom: use `.` as default path

Flags and generated help text show `"."` as default for `--path`.  The value is converted into the absolute path when a config command struct is generated from the flags.

This is related to #1169 