### PR TITLE
Fix a broken link in docs

### DIFF
--- a/docs/function-developers/golang.md
+++ b/docs/function-developers/golang.md
@@ -23,7 +23,7 @@ fn
 Aside from the `func.yaml` file, this looks like the beginning of just about
 any Go project. For now, we will ignore the `func.yaml` file, and just
 say that it is a configuration file that is used when building your project.
-If you're really interested, check out the [reference doc](func_yaml.md).
+If you're really interested, check out the [reference doc](../reference/func_yaml.md).
 To learn more about the CLI and the details for each supported command, see
 the [CLI Commands document](../reference/commands.txt).
 

--- a/docs/function-developers/nodejs.md
+++ b/docs/function-developers/nodejs.md
@@ -24,7 +24,7 @@ fn
 Aside from the `func.yaml` file, this looks like the beginning of just about
 any Node.js project. For now, we will ignore the `func.yaml` file, and just
 say that it is a configuration file that is used when building your project.
-If you're really interested, check out the [reference doc](func_yaml.md).
+If you're really interested, check out the [reference doc](../reference/func_yaml.md).
 To learn more about the CLI and the details for each supported command, see
 the [CLI Commands document](../reference/commands.txt).
 

--- a/docs/function-developers/python.md
+++ b/docs/function-developers/python.md
@@ -22,7 +22,7 @@ fn
 Aside from the `func.yaml` file, this looks like the beginning of just about
 any Python project. For now, we will ignore the `func.yaml` file, and just
 say that it is a configuration file that is used when building your project.
-If you're really interested, check out the [reference doc](func_yaml.md).
+If you're really interested, check out the [reference doc](../reference/func_yaml.md).
 To learn more about the CLI and the details for each supported command, see
 the [CLI Commands document](../reference/commands.txt).
 

--- a/docs/function-developers/quarkus.md
+++ b/docs/function-developers/quarkus.md
@@ -36,7 +36,7 @@ fn
 Aside from the `func.yaml` file, this looks like the beginning of just about
 any Java Maven project. For now, we will ignore the `func.yaml` file, and just
 say that it is a configuration file that is used when building your project.
-If you're really interested, check out the [reference doc](func_yaml.md).
+If you're really interested, check out the [reference doc](../reference/func_yaml.md).
 To learn more about the CLI and the details for each supported command, see
 the [CLI Commands document](../reference/commands.txt).
 

--- a/docs/function-developers/typescript.md
+++ b/docs/function-developers/typescript.md
@@ -27,7 +27,7 @@ fn
 Aside from the `func.yaml` file, this looks like the beginning of just about
 any TypeScript project. For now, we will ignore the `func.yaml` file, and just
 say that it is a configuration file used when building your project.
-If you are interested, check out the [reference doc](func_yaml.md).
+If you are interested, check out the [reference doc](../reference/func_yaml.md).
 To learn more about the CLI and the details for each supported command, see
 the [CLI Commands document](../reference/commands.txt).
 


### PR DESCRIPTION
# Changes
- :bug: Fix a broken link in docs

/kind documentation
