### PR TITLE
fix: trailing white spaces in genrated docs

### DIFF
--- a/docs/generator/main.go
+++ b/docs/generator/main.go
@@ -6,6 +6,7 @@ import (
 	"html/template"
 	"io/ioutil"
 	"os"
+	"regexp"
 	"strings"
 
 	"github.com/spf13/cobra"
@@ -117,7 +118,10 @@ func writeMarkdown(c *cobra.Command, name string, opts TemplateOptions) error {
 		fmt.Fprintf(os.Stderr, "unable to process help text: %v", err)
 	}
 
-	if err := ioutil.WriteFile(targetDir+"/"+name+".md", out.Bytes(), 0666); err != nil {
+	re := regexp.MustCompile(`[^\S\r\n]+\n`)
+	data := re.ReplaceAll(out.Bytes(), []byte{'\n'}) // trim white spaces before EOL
+
+	if err := ioutil.WriteFile(targetDir+"/"+name+".md", data, 0666); err != nil {
 		return err
 	}
 	return nil

--- a/docs/reference/func_create.md
+++ b/docs/reference/func_create.md
@@ -43,7 +43,7 @@ DESCRIPTION
 	  springboot   http
 	  typescript   cloudevents
 	  typescript   http
-	  
+
 
 	To install more language runtimes and their templates see 'func repository'.
 
@@ -59,7 +59,7 @@ EXAMPLES
 
 	o Create a Go function which handles CloudEvents in ./myfunc.
 	  $ func create -l go -t cloudevents myfunc
-		
+
 
 ```
 func create [flags]

--- a/docs/reference/func_templates.md
+++ b/docs/reference/func_templates.md
@@ -16,7 +16,7 @@ DESCRIPTION
 
 	To specify a URI of a single, specific repository for which templates
 	should be displayed, use the --repository flag.
-	
+
 	Installed repositories are by default located at ~/.func/repositories
 	($XDG_CONFIG_HOME/.func/repositories).  This can be overridden with
 	$FUNC_REPOSITORIES_PATH.


### PR DESCRIPTION
# Changes

- :bug: Trim white spaces before EOL in generated markdown files.