### PR TITLE
fix: on cluster builds when buildEnvs contains only one build environment

### DIFF
--- a/pipelines/tekton/resources.go
+++ b/pipelines/tekton/resources.go
@@ -133,7 +133,7 @@ func generatePipelineRun(f fn.Function, labels map[string]string) *pplnv1beta1.P
 		for _, e := range f.BuildEnvs {
 			envs = append(envs, e.KeyValuePair())
 		}
-		buildEnvs = pplnv1beta1.NewArrayOrString(envs[0], envs[1:]...)
+		buildEnvs.ArrayVal = envs
 	}
 
 	params := []pplnv1beta1.Param{


### PR DESCRIPTION
# Changes

- :bug: Fix on cluster build, deployment issues when buildEnv has only one env var, example:

/kind bug

Fixes #1199 
