### PR TITLE
doc: update generated docs for 'deploy'

### DIFF
--- a/docs/reference/func_deploy.md
+++ b/docs/reference/func_deploy.md
@@ -38,8 +38,8 @@ func deploy --image quay.io/myuser/myfunc -n myns
 ### Options
 
 ```
-  -b, --build string           Build specifies the way the function should be built. Supported types are "disabled", "local" or "git" (Env: $FUNC_BUILD) (default "local")
-      --builder string         build strategy to use when creating the underlying image. Currently supported build strategies are "pack" or "s2i". (default "pack")
+      --build string           Build specifies the way the function should be built. Supported types are "disabled", "local" or "git" (Env: $FUNC_BUILD) (default "local")
+  -b, --builder string         build strategy to use when creating the underlying image. Currently supported build strategies are "pack" and "s2i". (default "pack")
       --builder-image string   builder image, either an as a an image name or a mapping name.
                                Specified value is stored in func.yaml (as 'builder' field) for subsequent builds. ($FUNC_BUILDER_IMAGE)
   -c, --confirm                Prompt to confirm all configuration options (Env: $FUNC_CONFIRM)


### PR DESCRIPTION
# Changes

- :broom: Update generated docs for `func deploy`

A recent PR made changes to the flags for `func deploy`. See: https://github.com/knative-sandbox/kn-plugin-func/pull/1202

/kind documentation
/assign @matejvasek 