### PR TITLE
fix: check for `--image` flag in build command

### DIFF
--- a/cmd/build.go
+++ b/cmd/build.go
@@ -151,7 +151,7 @@ func runBuild(cmd *cobra.Command, _ []string, newClient ClientFactory) (err erro
 	}
 
 	// If the function does not yet have an image name and one was not provided on the command line
-	if function.Image == "" {
+	if function.Image == "" && config.Image == "" {
 		//  AND a --registry was not provided, then we need to
 		// prompt for a registry from which we can derive an image name.
 		if config.Registry == "" {
@@ -171,6 +171,7 @@ func runBuild(cmd *cobra.Command, _ []string, newClient ClientFactory) (err erro
 
 		// We have the registry, so let's use it to derive the function image name
 		config.Image = deriveImage(config.Image, config.Registry, config.Path)
+
 		function.Image = config.Image
 	}
 

--- a/cmd/build_test.go
+++ b/cmd/build_test.go
@@ -24,13 +24,7 @@ func TestBuild_ImageFlag(t *testing.T) {
 	root, cleanup := Mktemp(t)
 	defer cleanup()
 
-	// Write a func.yaml config which does not specify an image
-	funcYaml := `name: foo
-runtime: go
-builder: pack
-created: 2022-01-01T00:00:00+00:00
-`
-	if err := ioutil.WriteFile("func.yaml", []byte(funcYaml), 0600); err != nil {
+	if err := fn.New().Create(fn.Function{Runtime: "go", Root: root}); err != nil {
 		t.Fatal(err)
 	}
 


### PR DESCRIPTION
# Changes

- :bug: check for `--image` flag in build command

If the user provides an `--image` flag on the command line, it should be used. This commit modifies the image resolving code to check whether or not the image name was provided on the command line.

Fixes: https://github.com/knative-sandbox/kn-plugin-func/issues/1125

/kind bug

**Release Note**
```release-note
Fixes a regression where the `--image` flag on `func build` was not being used
```
