### PR TITLE
use the correct sample repository link in command usage

### DIFF
--- a/cmd/languages.go
+++ b/cmd/languages.go
@@ -46,7 +46,7 @@ EXAMPLES
 	  $ {{.Name}} languages --json
 
 	o Return language runtimes in a specific repository
-		$ {{.Name}} languages --repository=https://github.com/boson-project/func-templates
+		$ {{.Name}} languages --repository=https://github.com/boson-project/templates
 `,
 		SuggestFor: []string{"language", "runtime", "runtimes", "lnaguages", "languagse",
 			"panguages", "manguages", "kanguages", "lsnguages", "lznguages"},

--- a/cmd/templates.go
+++ b/cmd/templates.go
@@ -50,7 +50,7 @@ EXAMPLES
 	  $ {{.Name}} templates --json
 
 	o Return Go templates in a specific repository
-		$ {{.Name}} templates go --repository=https://github.com/boson-project/func-templates
+		$ {{.Name}} templates go --repository=https://github.com/boson-project/templates
 `,
 		SuggestFor: []string{"template", "templtaes", "templatse", "remplates",
 			"gemplates", "yemplates", "tenplates", "tekplates", "tejplates",

--- a/docs/reference/func_languages.md
+++ b/docs/reference/func_languages.md
@@ -35,7 +35,7 @@ EXAMPLES
 	  $ func languages --json
 
 	o Return language runtimes in a specific repository
-		$ func languages --repository=https://github.com/boson-project/func-templates
+		$ func languages --repository=https://github.com/boson-project/templates
 
 
 ```

--- a/docs/reference/func_templates.md
+++ b/docs/reference/func_templates.md
@@ -36,7 +36,7 @@ EXAMPLES
 	  $ func templates --json
 
 	o Return Go templates in a specific repository
-		$ func templates go --repository=https://github.com/boson-project/func-templates
+		$ func templates go --repository=https://github.com/boson-project/templates
 
 
 ```


### PR DESCRIPTION
Since `boson-project/func-templates` doesn't exist now, replace it with the correct link `boson-project/templates`.

# Changes

- :bug: use the correct sample repository link in command usage

/kind bug
