### PR TITLE
fix: on cluster build - populate image name if not set

### DIFF
--- a/pipelines/tekton/pipeplines_provider.go
+++ b/pipelines/tekton/pipeplines_provider.go
@@ -121,7 +121,7 @@ func (pp *PipelinesProvider) Run(ctx context.Context, f fn.Function) error {
 
 	registry, err := docker.GetRegistry(f.Image)
 	if err != nil {
-		return err
+		return fmt.Errorf("problem in resolving image registry name: %v", err)
 	}
 
 	pp.progressListener.Stopping()


### PR DESCRIPTION
Signed-off-by: Zbynek Roubalik <zroubalik@gmail.com>

The recent changes in function image generation brought regression in on cluster build. If we tried to run a pipeline without image specified, it wasn't able to generate the correct image name.

ie. following `func.yaml` 
```yaml
specVersion: 0.25.0
name: test-function
namespace: default
runtime: node
registry: docker.io/zroubalik
image: ""
imageDigest: ""
build: git
...
```
fails with: 
```
🕐 Creating Pipeline resources
Error: failed to run pipeline: could not parse reference: 
```

This PR improves the error message as well.


<!-- Thanks for sending a pull request! -->

# Changes

<!-- 
Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! 

- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

- :bug: on cluster build - populate image name if not set


<!--
In addition, categorize the changes you're making using the "/kind" Prow command, example:

/kind <kind>

Supported kinds are: api-change, bug, cleanup, deprecation, removal, documentation, enhancement, performance

-->
/kind bug

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->

