### PR TITLE
fix: on cluster build - workaround for Tekton issue with empty array

### DIFF
--- a/pipelines/tekton/resources.go
+++ b/pipelines/tekton/resources.go
@@ -134,6 +134,10 @@ func generatePipelineRun(f fn.Function, labels map[string]string) *pplnv1beta1.P
 			envs = append(envs, e.KeyValuePair())
 		}
 		buildEnvs.ArrayVal = envs
+	} else {
+		// need to hack empty BuildEnvs array on Tekton v0.39.0+
+		// until https://github.com/tektoncd/pipeline/issues/5149 is resolved and released
+		buildEnvs.ArrayVal = append(buildEnvs.ArrayVal, "=")
 	}
 
 	params := []pplnv1beta1.Param{


### PR DESCRIPTION
Signed-off-by: Zbynek Roubalik <zroubalik@gmail.com>

<!-- Thanks for sending a pull request! -->


Need to hack empty BuildEnvs array on Tekton v0.39.0+  untill https://github.com/tektoncd/pipeline/issues/5149 is resolved and released.

Withouth this change on-cluster-builds fail on Tekton v0.39.0+ if there is not any Build Env specifed.

# Changes

<!-- 
Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! 

- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

- :bug: on cluster build - workaround for Tekton issue with empty array


<!--
In addition, categorize the changes you're making using the "/kind" Prow command, example:

/kind <kind>

Supported kinds are: api-change, bug, cleanup, deprecation, removal, documentation, enhancement, performance

-->
/kind bug

