### PR TITLE
fixed a variable name error in docs

### DIFF
--- a/docs/function-developers/python.md
+++ b/docs/function-developers/python.md
@@ -122,7 +122,7 @@ for more information.
 #### Example
 ```python
 def main(context: Context):
-    data = { "message": "Howdy!" }
+    body = { "message": "Howdy!" }
     headers = { "content-type": "application/json" }
     return body, 200, headers
 ```


### PR DESCRIPTION
# Changes
- :bug: variable `body` was misspelled to data
