### PR TITLE
fix: downstream e2e fails with unknown default builder image

### DIFF
--- a/test/_e2e/cmd_invoke_test.go
+++ b/test/_e2e/cmd_invoke_test.go
@@ -59,7 +59,7 @@ func TestInvoke(t *testing.T) {
 
 	run(t, bin, prefix, "create", "--language=go", "--template=cloudevents", cwd)
 	set(t, "handle.go", TestInvokeFunctionImpl)
-	run(t, bin, prefix, "deploy", "--registry", GetRegistry())
+	run(t, bin, prefix, "deploy", "--builder=pack", "--registry", GetRegistry())
 	infoOut := run(t, bin, prefix, "info", "--output", "plain")
 	run(t, bin, prefix, "invoke", "--verbose=true", "--content-type=text/plain", "--source=func:set", "--data=TEST")
 


### PR DESCRIPTION
Downstream changes default builder to S2I, which currently has no
default Go builder image.  This PR pins the use of pack for the invocation test, which has support for all our core runtimes.

/kind bug