### PR TITLE
fix: use flag value as default or when changed only

### DIFF
--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -128,14 +128,16 @@ func runDeploy(cmd *cobra.Command, _ []string, newClient ClientFactory) (err err
 	if !f.Initialized() {
 		return fmt.Errorf("'%v' does not contain an initialized function", config.Path)
 	}
-	if config.Registry != "" {
+	if f.Registry == "" || cmd.Flags().Changed("registry") {
+		// Sets default AND accepts any user-provided overrides
 		f.Registry = config.Registry
+	}
+	if f.Builder == "" || cmd.Flags().Changed("builder") {
+		// Sets default AND accepts any user-provided overrides
+		f.Builder = config.Builder
 	}
 	if config.Image != "" {
 		f.Image = config.Image
-	}
-	if config.Builder != "" {
-		f.Builder = config.Builder
 	}
 
 	f.Namespace, err = checkNamespaceDeploy(f.Namespace, config.Namespace)


### PR DESCRIPTION
- :bug: fixes an error seen downstream when IsOpenShift results in non-zero flag default, causing tests to fail
- :broom: updates other affected commands/flags (the registry and builder flag on both deploy and build subcommands)

Updates the `deploy` and `build` commands to more selectively use the value of flags whose default is a non-zero value and whose value maps to an attribute on the function being operated upon.

In particular, the flag default will only be used when the function has no value yet defined (as a default), or when the value has been provided by the user (an override).

Note that this logic is a bit janky, and will be refined with the upcoming Global Config PR, which will provide a default value to the flag which will already take into account both the static default and the existing function state.  Then the resltant config object can always be used directly with no conditionals.

/fixes #941 

/kind bug