### PR TITLE
feat: UX improvements for docker/podman usage

### DIFF
--- a/docker/docker_client_ssh_test.go
+++ b/docker/docker_client_ssh_test.go
@@ -39,11 +39,15 @@ func TestNewDockerClientWithSSH(t *testing.T) {
 
 	defer WithEnvVar(t, "DOCKER_HOST", fmt.Sprintf("ssh://user:pwd@%s", sshConf.address))()
 
-	dockerClient, _, err := docker.NewClient(client.DefaultDockerHost)
+	dockerClient, dockerHostInRemote, err := docker.NewClient(client.DefaultDockerHost)
 	if err != nil {
 		t.Fatal(err)
 	}
 	defer dockerClient.Close()
+
+	if dockerHostInRemote != `unix://`+sshDockerSocket {
+		t.Errorf("bad remote DOCKER_HOST: expected %q but got %q", `unix://`+sshDockerSocket, dockerHostInRemote)
+	}
 
 	_, err = dockerClient.Ping(ctx)
 	if err != nil {


### PR DESCRIPTION
# Changes

- :gift: Better error message if docker/podman not present.
- :gift: Auto detect podman machine's socket on mac/win, so user doesn't have to set `DOCKER_HOST`.
