### PR TITLE
fix: set seccomp profile for dialer pod

### DIFF
--- a/k8s/dialer.go
+++ b/k8s/dialer.go
@@ -150,6 +150,7 @@ func (c *contextDialer) startDialerPod(ctx context.Context) (err error) {
 						AllowPrivilegeEscalation: new(bool),
 						RunAsNonRoot:             &runAsNonRoot,
 						Capabilities:             &coreV1.Capabilities{Drop: []coreV1.Capability{"ALL"}},
+						SeccompProfile:           &coreV1.SeccompProfile{Type: coreV1.SeccompProfileTypeRuntimeDefault},
 					},
 				},
 			},


### PR DESCRIPTION
# Changes

- :bug: Set seccomp profile for dialer pod. This is required by OpenShift 4.12.

