### PR TITLE
fix: correct error handling in filesystem tests

### DIFF
--- a/filesystem_test.go
+++ b/filesystem_test.go
@@ -231,7 +231,7 @@ func initGitFS(t *testing.T) Filesystem {
 
 	result, err := filesystemFromRepo(uri)
 	if err != nil {
-		t.Fatal(t)
+		t.Fatal(err)
 	}
 	return result
 }


### PR DESCRIPTION
Fixes a small typo in filesystem tests, so errors output correctly
