### PR TITLE
chore: dialer improvements

### DIFF
--- a/k8s/dialer.go
+++ b/k8s/dialer.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"net"
+	"os"
 	"sync"
 	"time"
 
@@ -130,6 +131,11 @@ func (c *contextDialer) startDialerPod(ctx context.Context) (err error) {
 		}
 	}()
 
+	img := socatImage
+	if i, ok := os.LookupEnv("SOCAT_IMAGE"); ok {
+		img = i
+	}
+
 	runAsNonRoot := true
 	pod := &coreV1.Pod{
 		ObjectMeta: metaV1.ObjectMeta{
@@ -141,10 +147,10 @@ func (c *contextDialer) startDialerPod(ctx context.Context) (err error) {
 			Containers: []coreV1.Container{
 				{
 					Name:      c.podName,
-					Image:     socatImage,
+					Image:     img,
 					Stdin:     true,
 					StdinOnce: true,
-					Args:      []string{"-u", "-", "OPEN:/dev/null,append"},
+					Command:   []string{"socat", "-u", "-", "OPEN:/dev/null"},
 					SecurityContext: &coreV1.SecurityContext{
 						Privileged:               new(bool),
 						AllowPrivilegeEscalation: new(bool),

--- a/k8s/dialer_test.go
+++ b/k8s/dialer_test.go
@@ -181,7 +181,7 @@ func TestDialUnreachable(t *testing.T) {
 		t.Error("error was expected but got nil")
 		return
 	}
-	if !strings.Contains(err.Error(), "Name does not resolve") {
+	if !strings.Contains(err.Error(), "not resolve") {
 		t.Errorf("error %q doesn't containe expected sub-string: ", err.Error())
 	}
 }


### PR DESCRIPTION
# Changes

- :gift: Independence of `socat` image entrypoint.
- :gift: The `socat` image is configurable via environment variable.
- :test_tube: Make test assert less strict.

