### PR TITLE
fix: s2i on cluster build of Quarkus functions

### DIFF
--- a/pipelines/resources/tekton/task/func-s2i/0.1/func-s2i.yaml
+++ b/pipelines/resources/tekton/task/func-s2i/0.1/func-s2i.yaml
@@ -37,6 +37,9 @@ spec:
       type: array
       description: Environment variables to set during _build-time_.
       default: []
+    - name: S2I_IMAGE_SCRIPTS_URL
+      description: The URL containing the default assemble and run scripts for the builder image.
+      default: "image:///usr/libexec/s2i"
   workspaces:
     - name: source
     - name: sslcertdir
@@ -69,6 +72,7 @@ spec:
         echo "------------------------------"
 
         /usr/local/bin/s2i --loglevel=$(params.LOGLEVEL) build $(params.PATH_CONTEXT) $(params.BUILDER_IMAGE) \
+        --image-scripts-url $(params.S2I_IMAGE_SCRIPTS_URL) \
         --as-dockerfile /gen-source/Dockerfile.gen --environment-file /env-vars/env-file
       volumeMounts:
         - mountPath: /gen-source

--- a/pipelines/tekton/resources.go
+++ b/pipelines/tekton/resources.go
@@ -85,6 +85,10 @@ func generatePipeline(f fn.Function, labels map[string]string) *pplnv1beta1.Pipe
 
 	} else if f.Builder == builders.S2I {
 		// ----- S2I build related properties
+
+		params = append(params, pplnv1beta1.ParamSpec{Name: "s2iImageScriptsUrl", Description: "URL containing the default assemble and run scripts for the builder image.",
+			Default: pplnv1beta1.NewArrayOrString("image:///usr/libexec/s2i")})
+
 		taskBuild = taskS2iBuild(taskNameFetchSources)
 		referenceImageFromPreviousTaskResults = true
 	}
@@ -194,6 +198,10 @@ func generatePipelineRun(f fn.Function, labels map[string]string) *pplnv1beta1.P
 			},
 			SubPath: "cache",
 		})
+	} else if f.Builder == builders.S2I {
+		if f.Runtime == "quarkus" {
+			params = append(params, pplnv1beta1.Param{Name: "s2iImageScriptsUrl", Value: *pplnv1beta1.NewArrayOrString("image:///usr/local/s2i")})
+		}
 	}
 
 	// ----- PipelineRun definition

--- a/pipelines/tekton/tasks.go
+++ b/pipelines/tekton/tasks.go
@@ -70,6 +70,7 @@ func taskS2iBuild(runAfter string) pplnv1beta1.PipelineTask {
 			Type:     pplnv1beta1.ParamTypeArray,
 			ArrayVal: []string{"$(params.buildEnvs[*])"},
 		}},
+		{Name: "S2I_IMAGE_SCRIPTS_URL", Value: *pplnv1beta1.NewArrayOrString("$(params.s2iImageScriptsUrl)")},
 	}
 	return pplnv1beta1.PipelineTask{
 		Name: taskNameBuild,


### PR DESCRIPTION
Signed-off-by: Zbynek Roubalik <zroubalik@gmail.com>

Java related S2I builder images have S2I build scripts in `/usr/local/s2i`, default location for other languages is `/usr/libexec/s2i`.

<!-- Thanks for sending a pull request! -->

# Changes

<!-- 
Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! 

- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

- :bug: s2i on cluster build of Quarkus functions


<!--
In addition, categorize the changes you're making using the "/kind" Prow command, example:

/kind <kind>

Supported kinds are: api-change, bug, cleanup, deprecation, removal, documentation, enhancement, performance

-->
/kind bug

