### PR TITLE
chore: update imjasonh/setup-ko to v0.6

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -32,7 +32,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v2
-        with: 
+        with:
           go-version: "1.17"
       # Standard build tasks
       - name: Build
@@ -72,7 +72,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v2
-        with: 
-          go-version: "1.17"
-      - uses: imjasonh/setup-ko@v0.4
-      - run: ko publish -B ./cmd/func
+        with:
+          go-version: "1.18"
+      - uses: imjasonh/setup-ko@v0.6
+      - run: ko build -B ./cmd/func


### PR DESCRIPTION
# Changes

- 🧹 `ko` recently moved to its own github org which broke versions of `ko` prior to 0.6. This should resolve issues we have been seeing with the failure to publish the func image over the last week.

Signed-off-by: Lance Ball <lball@redhat.com>

/kind chore
