### PR TITLE
fix: updated func-deploy tekton task to aling with the new deploy command build flag options

### DIFF
--- a/pipelines/resources/tekton/task/func-deploy/0.1/func-deploy.yaml
+++ b/pipelines/resources/tekton/task/func-deploy/0.1/func-deploy.yaml
@@ -27,4 +27,4 @@ spec:
     image: "ghcr.io/knative-sandbox/kn-plugin-func/func:latest"
     script: |
       export FUNC_IMAGE="$(params.image)"
-      func deploy --verbose --build=disabled --push=false --path=$(params.path)
+      func deploy --verbose --build=false --push=false --path=$(params.path)


### PR DESCRIPTION
# Changes

- :bug:  updated func-deploy tekton task to alingh with to new deploy flags

/kind bug

`func deploy` command now uses `--build false` instead of `--build disabled`, so changing `func-deploy` tekton task to reflect this change