### PR TITLE
fix: wrong-error-message-reported-in-command-func-templates-repository

### DIFF
--- a/cmd/client.go
+++ b/cmd/client.go
@@ -34,7 +34,7 @@ type ClientConfig struct {
 // for use by commands.
 // See the NewClient constructor which is the fully populated ClientFactory used
 // by commands by default.
-// See NewClientFactory which constructs a minimal CientFactory for use
+// See NewClientFactory which constructs a minimal ClientFactory for use
 // during testing.
 type ClientFactory func(ClientConfig, ...fn.Option) (*fn.Client, func())
 
@@ -52,7 +52,7 @@ func NewClientFactory(n func() *fn.Client) ClientFactory {
 // NewClient constructs an fn.Client with the majority of
 // the concrete implementations set.  Provide additional Options to this constructor
 // to override or augment as needed, or override the ClientFactory passed to
-// commands entirely to mock for testing. Note the reutrned cleanup function.
+// commands entirely to mock for testing. Note the returned cleanup function.
 // 'Namespace' is optional.  If not provided (see DefaultNamespace commentary),
 // the currently configured is used.
 // 'Verbose' indicates the system should write out a higher amount of logging.

--- a/cmd/templates_test.go
+++ b/cmd/templates_test.go
@@ -1,7 +1,10 @@
 package cmd
 
 import (
+	"errors"
 	"testing"
+
+	"gotest.tools/v3/assert"
 
 	fn "knative.dev/kn-plugin-func"
 	. "knative.dev/kn-plugin-func/testing"
@@ -139,4 +142,25 @@ http`
 		t.Fatalf("expected JSON:\n'%v'\ngot:\n'%v'\n", expected, output)
 	}
 
+}
+
+func TestTemplates_ErrTemplateRepoDoesNotExist(t *testing.T) {
+	defer t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	cmd := NewTemplatesCmd(NewClientFactory(func() *fn.Client {
+		return fn.New()
+	}))
+	cmd.SetArgs([]string{"--repository", "https://github.com/boson-project/repo-does-not-exist"})
+	err := cmd.Execute()
+	assert.Assert(t, err != nil)
+	assert.Assert(t, errors.Is(err, ErrTemplateRepoDoesNotExist))
+}
+
+func TestTemplates_WrongRepositoryUrl(t *testing.T) {
+	defer t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	cmd := NewTemplatesCmd(NewClientFactory(func() *fn.Client {
+		return fn.New()
+	}))
+	cmd.SetArgs([]string{"--repository", "wrong://github.com/boson-project/repo-does-not-exist"})
+	err := cmd.Execute()
+	assert.Assert(t, err != nil)
 }


### PR DESCRIPTION
Fixes: https://github.com/knative-sandbox/kn-plugin-func/issues/1206
```release-notes
fixes a bug in the display of repository urls in the event of an error
```