### PR TITLE
update go version to 1.18 on go.mod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module knative.dev/kn-plugin-func
 
-go 1.17
+go 1.18
 
 require (
 	github.com/AlecAivazis/survey/v2 v2.3.2


### PR DESCRIPTION
# Changes

- :broom: updating go version to 1.18 on go.mod

/kind cleanup

We can't use 1.17 to build anyway, once deps depends on 1.18.