### PR TITLE
chore: linkage assignable socatImage

### DIFF
--- a/k8s/dialer.go
+++ b/k8s/dialer.go
@@ -23,9 +23,7 @@ import (
 	"k8s.io/client-go/tools/remotecommand"
 )
 
-const (
-	socatImage = "quay.io/boson/alpine-socat:1.7.4.3-r1-non-root"
-)
+var socatImage = "quay.io/boson/alpine-socat:1.7.4.3-r1-non-root"
 
 // NewInClusterDialer creates context dialer that will dial TCP connections via POD running in k8s cluster.
 // This is useful when accessing k8s services that are not exposed outside cluster (e.g. openshift image registry).


### PR DESCRIPTION
A `var` can be set at build (link) time as opposed to a `const`.
