### PR TITLE
fix: registry prompt result being ignored

### DIFF
--- a/cmd/build.go
+++ b/cmd/build.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"errors"
 	"fmt"
+
 	"github.com/AlecAivazis/survey/v2"
 	"github.com/AlecAivazis/survey/v2/terminal"
 	"github.com/ory/viper"

--- a/cmd/build.go
+++ b/cmd/build.go
@@ -3,7 +3,6 @@ package cmd
 import (
 	"errors"
 	"fmt"
-
 	"github.com/AlecAivazis/survey/v2"
 	"github.com/AlecAivazis/survey/v2/terminal"
 	"github.com/ory/viper"
@@ -148,13 +147,8 @@ func runBuild(cmd *cobra.Command, _ []string, newClient ClientFactory) (err erro
 		return
 	}
 
-	client, done := newClient(ClientConfig{Verbose: config.Verbose},
-		fn.WithRegistry(config.Registry),
-		fn.WithBuilder(builder))
-	defer done()
-
 	// Default Client Registry, Function Registry or explicit Image is required
-	if client.Registry() == "" && f.Registry == "" && f.Image == "" {
+	if config.Registry == "" && f.Registry == "" && f.Image == "" {
 		// It is not necessary that we validate here, since the client API has
 		// its own validation, but it does give us the opportunity to show a very
 		// cli-specific and detailed error message and (at least for now) default
@@ -168,10 +162,15 @@ func runBuild(cmd *cobra.Command, _ []string, newClient ClientFactory) (err erro
 				return ErrRegistryRequired
 			}
 			fmt.Println("Note: building a function the first time will take longer than subsequent builds")
+		} else {
+			return ErrRegistryRequired
 		}
-
-		return ErrRegistryRequired
 	}
+
+	client, done := newClient(ClientConfig{Verbose: config.Verbose},
+		fn.WithRegistry(config.Registry),
+		fn.WithBuilder(builder))
+	defer done()
 
 	// This preemptive write call will be unnecessary when the API is updated
 	// to use Function instances rather than file paths. For now it must write


### PR DESCRIPTION
# Changes

- :bug: Fix bug when registry prompt answer is ignored on `func build`.

/kind bug


```release-note
fix: bug when registry prompt answer is ignored on `func build`.
```
