### PR TITLE
fix: default readiness endpoint

### DIFF
--- a/repository.go
+++ b/repository.go
@@ -141,7 +141,7 @@ func NewRepository(name, uri string) (r Repository, err error) {
 		funcDefaults: funcDefaults{
 			HealthEndpoints: HealthEndpoints{
 				Liveness:  DefaultLivenessEndpoint,
-				Readiness: DefaultLivenessEndpoint,
+				Readiness: DefaultReadinessEndpoint,
 			},
 			Invocation: Invocation{Format: DefaultInvocationFormat},
 		},


### PR DESCRIPTION
- :bug: fix: default readiness endpoint

This bug is not expressed, because the correct values are currently read from template manifests rather than static defaults, but once that bug/decision is changed per #1281; this incorrect default would have manifested in incorrect initial functions.