### PR TITLE
chore: cmd test cleanup

### DIFF
--- a/cmd/build_test.go
+++ b/cmd/build_test.go
@@ -6,7 +6,6 @@ import (
 
 	fn "knative.dev/kn-plugin-func"
 	"knative.dev/kn-plugin-func/mock"
-	. "knative.dev/kn-plugin-func/testing"
 )
 
 // TestBuild_ImageFlag ensures that the image flag is used when specified.
@@ -15,9 +14,7 @@ func TestBuild_ImageFlag(t *testing.T) {
 		args    = []string{"--image", "docker.io/tigerteam/foo"}
 		builder = mock.NewBuilder()
 	)
-
-	root, cleanup := Mktemp(t)
-	defer cleanup()
+	root := fromTempDirectory(t)
 
 	if err := fn.New().Create(fn.Function{Runtime: "go", Root: root, Registry: TestRegistry}); err != nil {
 		t.Fatal(err)
@@ -48,9 +45,7 @@ func TestBuild_ImageFlag(t *testing.T) {
 // provided (or exist on the function already), and the client has not been
 // instantiated with a default registry, an ErrRegistryRequired is received.
 func TestBuild_RegistryOrImageRequired(t *testing.T) {
-	t.Helper()
-	root, rm := Mktemp(t)
-	defer rm()
+	root := fromTempDirectory(t)
 
 	if err := fn.New().Create(fn.Function{Runtime: "go", Root: root}); err != nil {
 		t.Fatal(err)
@@ -106,8 +101,7 @@ func TestBuild_BuilderValidated(t *testing.T) {
 // - Push not triggered after an unsuccessful build
 // - Push can be disabled
 func TestBuild_Push(t *testing.T) {
-	root, rm := Mktemp(t)
-	defer rm()
+	root := fromTempDirectory(t)
 
 	f := fn.Function{
 		Root:     root,

--- a/cmd/config_test.go
+++ b/cmd/config_test.go
@@ -14,7 +14,6 @@ import (
 )
 
 func TestListEnvs(t *testing.T) {
-
 	mock := newMockLoaderSaver()
 	foo := "foo"
 	bar := "bar"

--- a/cmd/delete_test.go
+++ b/cmd/delete_test.go
@@ -6,7 +6,6 @@ import (
 
 	fn "knative.dev/kn-plugin-func"
 	"knative.dev/kn-plugin-func/mock"
-	. "knative.dev/kn-plugin-func/testing"
 )
 
 // TestDelete_ByName ensures that running delete specifying the name of the
@@ -46,8 +45,7 @@ func TestDelete_ByName(t *testing.T) {
 // TestDelete_ByProject ensures that running delete with a valid project as its
 // context invokes remove and with the correct name (reads name from func.yaml)
 func TestDelete_ByProject(t *testing.T) {
-	// from within a new temporary directory
-	defer Fromtemp(t)()
+	_ = fromTempDirectory(t)
 
 	// Write a func.yaml config which specifies a name
 	funcYaml := `name: bar

--- a/cmd/deploy_test.go
+++ b/cmd/deploy_test.go
@@ -14,7 +14,6 @@ import (
 	fn "knative.dev/kn-plugin-func"
 	"knative.dev/kn-plugin-func/builders"
 	"knative.dev/kn-plugin-func/mock"
-	. "knative.dev/kn-plugin-func/testing"
 )
 
 const TestRegistry = "example.com/alice"
@@ -24,8 +23,7 @@ type commandConstructor func(ClientFactory) *cobra.Command
 // TestDeploy_Default ensures that running deploy on a valid default Function
 // (only required options populated; all else default) completes successfully.
 func TestDeploy_Default(t *testing.T) {
-	root, rm := Mktemp(t)
-	defer rm()
+	root := fromTempDirectory(t)
 
 	// A Function with the minimum required values for deployment populated.
 	f := fn.Function{
@@ -57,8 +55,7 @@ func TestDeploy_RegistryOrImageRequired(t *testing.T) {
 
 func testRegistryOrImageRequired(cmdFn commandConstructor, t *testing.T) {
 	t.Helper()
-	root, rm := Mktemp(t)
-	defer rm()
+	root := fromTempDirectory(t)
 
 	if err := fn.New().Create(fn.Function{Runtime: "go", Root: root}); err != nil {
 		t.Fatal(err)
@@ -95,8 +92,7 @@ func TestDeploy_ImageAndRegistry(t *testing.T) {
 
 func testImageAndRegistry(cmdFn commandConstructor, t *testing.T) {
 	t.Helper()
-	root, rm := Mktemp(t)
-	defer rm()
+	root := fromTempDirectory(t)
 
 	if err := fn.New().Create(fn.Function{Runtime: "go", Root: root}); err != nil {
 		t.Fatal(err)
@@ -171,8 +167,7 @@ func TestDeploy_InvalidRegistry(t *testing.T) {
 
 func testInvalidRegistry(cmdFn commandConstructor, t *testing.T) {
 	t.Helper()
-	root, rm := Mktemp(t)
-	defer rm()
+	root := fromTempDirectory(t)
 
 	f := fn.Function{
 		Root:    root,
@@ -204,8 +199,7 @@ func TestDeploy_RegistryLoads(t *testing.T) {
 
 func testRegistryLoads(cmdFn commandConstructor, t *testing.T) {
 	t.Helper()
-	root, rm := Mktemp(t)
-	defer rm()
+	root := fromTempDirectory(t)
 
 	f := fn.Function{
 		Root:     root,
@@ -246,11 +240,9 @@ func TestDeploy_BuilderPersists(t *testing.T) {
 }
 
 func testBuilderPersists(cmdFn commandConstructor, t *testing.T) {
-	t.Setenv("KUBECONFIG", fmt.Sprintf("%s/testdata/kubeconfig_deploy_namespace", cwd()))
-
 	t.Helper()
-	root, rm := Mktemp(t)
-	defer rm()
+	t.Setenv("KUBECONFIG", fmt.Sprintf("%s/testdata/kubeconfig_deploy_namespace", cwd()))
+	root := fromTempDirectory(t)
 
 	if err := fn.New().Create(fn.Function{Runtime: "go", Root: root}); err != nil {
 		t.Fatal(err)
@@ -340,8 +332,7 @@ func TestDeploy_BuilderValidated(t *testing.T) {
 
 func testBuilderValidated(cmdFn commandConstructor, t *testing.T) {
 	t.Helper()
-	root, rm := Mktemp(t)
-	defer rm()
+	root := fromTempDirectory(t)
 
 	if err := fn.New().Create(fn.Function{Runtime: "go", Root: root}); err != nil {
 		t.Fatal(err)
@@ -406,8 +397,7 @@ func TestDeploy_RemoteBuildURLPermutations(t *testing.T) {
 	// returns a single test function for one possible permutation of the flags.
 	newTestFn := func(remote, build, url string) func(t *testing.T) {
 		return func(t *testing.T) {
-			root, rm := Mktemp(t)
-			defer rm()
+			root := fromTempDirectory(t)
 
 			// Create a new Function in the temp directory
 			if err := fn.New().Create(fn.Function{Runtime: "go", Root: root}); err != nil {
@@ -580,8 +570,7 @@ func Test_ImageWithDigestErrors(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			// Move into a new temp directory
-			root, rm := Mktemp(t)
-			defer rm()
+			root := fromTempDirectory(t)
 
 			// Create a new Function in the temp directory
 			if err := fn.New().Create(fn.Function{Runtime: "go", Root: root}); err != nil {
@@ -677,8 +666,7 @@ func Test_namespace(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			t.Helper()
-			root, rm := Mktemp(t)
-			defer rm()
+			root := fromTempDirectory(t)
 
 			// if running with an active kubeconfig
 			if test.context {
@@ -736,8 +724,7 @@ Test_namespaceCheck cases were refactored into:
 // TestDeploy_GitArgsPersist ensures that the git flags, if provided, are
 // persisted to the Function for subsequent deployments.
 func TestDeploy_GitArgsPersist(t *testing.T) {
-	root, rm := Mktemp(t)
-	defer rm()
+	root := fromTempDirectory(t)
 
 	var (
 		url    = "https://example.com/user/repo"
@@ -778,8 +765,7 @@ func TestDeploy_GitArgsPersist(t *testing.T) {
 // TestDeploy_GitArgsUsed ensures that any git values provided as flags are used
 // when invoking a remote deployment.
 func TestDeploy_GitArgsUsed(t *testing.T) {
-	root, rm := Mktemp(t)
-	defer rm()
+	root := fromTempDirectory(t)
 
 	var (
 		url    = "https://example.com/user/repo"
@@ -821,8 +807,7 @@ func TestDeploy_GitArgsUsed(t *testing.T) {
 // TestDeploy_GitURLBranch ensures that a --git-url which specifies the branch
 // in the URL is equivalent to providing --git-branch
 func TestDeploy_GitURLBranch(t *testing.T) {
-	root, rm := Mktemp(t)
-	defer rm()
+	root := fromTempDirectory(t)
 
 	if err := fn.New().Create(fn.Function{Runtime: "go", Root: root}); err != nil {
 		t.Fatal(err)
@@ -861,12 +846,8 @@ func TestDeploy_GitURLBranch(t *testing.T) {
 // TestDeploy_NamespaceDefaults ensures that when not specified, a users's
 // active kubernetes context is used for the namespace if available.
 func TestDeploy_NamespaceDefaults(t *testing.T) {
-	// Set kube context to test context
 	t.Setenv("KUBECONFIG", filepath.Join(cwd(), "testdata", "kubeconfig_deploy_namespace"))
-
-	// from a temp directory
-	root, rm := Mktemp(t)
-	defer rm()
+	root := fromTempDirectory(t)
 
 	// Create a new function
 	if err := fn.New().Create(fn.Function{Runtime: "go", Root: root}); err != nil {
@@ -913,8 +894,7 @@ func TestDeploy_NamespaceDefaults(t *testing.T) {
 // Also implicitly checks that the --namespace flag takes precidence over
 // the namespace of a previously deployed Function.
 func TestDeploy_NamespaceUpdateWarning(t *testing.T) {
-	root, rm := Mktemp(t)
-	defer rm()
+	root := fromTempDirectory(t)
 
 	// Create a Function which appears to have been deployed to 'myns'
 	f := fn.Function{
@@ -975,10 +955,7 @@ func TestDeploy_NamespaceUpdateWarning(t *testing.T) {
 func TestDeploy_NamespaceRedeployWarning(t *testing.T) {
 	// Change profile to one whose current profile is 'test-ns-deploy'
 	t.Setenv("KUBECONFIG", filepath.Join(cwd(), "testdata", "kubeconfig_deploy_namespace"))
-
-	// From within a temp directory
-	root, rm := Mktemp(t)
-	defer rm()
+	root := fromTempDirectory(t)
 
 	// Create a Function which appears to have been deployed to 'myns'
 	f := fn.Function{

--- a/cmd/invoke_test.go
+++ b/cmd/invoke_test.go
@@ -12,13 +12,11 @@ import (
 
 	fn "knative.dev/kn-plugin-func"
 	"knative.dev/kn-plugin-func/mock"
-	. "knative.dev/kn-plugin-func/testing"
 )
 
 // TestInvoke command executes the invocation path.
 func TestInvoke(t *testing.T) {
-	root, rm := Mktemp(t)
-	defer rm()
+	root := fromTempDirectory(t)
 
 	var invoked int32
 
@@ -78,8 +76,7 @@ func TestInvoke(t *testing.T) {
 // TestInvoke_Namespace ensures that invocation uses the Function's namespace
 // despite the currently active.
 func TestInvoke_Namespace(t *testing.T) {
-	root, rm := Mktemp(t)
-	defer rm()
+	root := fromTempDirectory(t)
 
 	// Create a Function in a non-active namespace
 	f := fn.Function{Runtime: "go", Root: root, Deploy: fn.DeploySpec{Namespace: "ns"}}

--- a/cmd/languages_test.go
+++ b/cmd/languages_test.go
@@ -10,8 +10,9 @@ import (
 // all supported languages is to print a plain text list of all the builtin
 // language runtimes.
 func TestLanguages_Default(t *testing.T) {
-	t.Setenv("XDG_CONFIG_HOME", t.TempDir()) // ignore user-added
-	buf := piped(t)                          // gather output
+	_ = fromTempDirectory(t)
+
+	buf := piped(t) // gather output
 	cmd := NewLanguagesCmd(NewClientFactory(func() *fn.Client {
 		return fn.New()
 	}))
@@ -35,8 +36,9 @@ typescript`
 // TestLanguages_JSON ensures that listing languages in --json format returns
 // builtin languages as a JSON array.
 func TestLanguages_JSON(t *testing.T) {
-	t.Setenv("XDG_CONFIG_HOME", t.TempDir()) // ignore user-added
-	buf := piped(t)                          // gather output
+	_ = fromTempDirectory(t)
+
+	buf := piped(t) // gather output
 	cmd := NewLanguagesCmd(NewClientFactory(func() *fn.Client {
 		return fn.New()
 	}))

--- a/cmd/run_test.go
+++ b/cmd/run_test.go
@@ -8,7 +8,6 @@ import (
 
 	fn "knative.dev/kn-plugin-func"
 	"knative.dev/kn-plugin-func/mock"
-	. "knative.dev/kn-plugin-func/testing"
 )
 
 func TestRun_Run(t *testing.T) {
@@ -100,7 +99,7 @@ created: 2009-11-10 23:00:00`,
 	for _, tt := range tests {
 		// run as a sub-test
 		t.Run(tt.name, func(t *testing.T) {
-			defer Fromtemp(t)()
+			_ = fromTempDirectory(t)
 
 			runner := mock.NewRunner()
 			if tt.runError != nil {

--- a/cmd/templates_test.go
+++ b/cmd/templates_test.go
@@ -12,8 +12,9 @@ import (
 // TestTemplates_Default ensures that the default behavior is listing all
 // templates for all language runtimes.
 func TestTemplates_Default(t *testing.T) {
-	t.Setenv("XDG_CONFIG_HOME", t.TempDir()) // ignore user-added
-	buf := piped(t)                          // gather output
+	_ = fromTempDirectory(t)
+
+	buf := piped(t) // gather output
 	cmd := NewTemplatesCmd(NewClientFactory(func() *fn.Client {
 		return fn.New()
 	}))
@@ -45,8 +46,9 @@ typescript   http`
 // TestTemplates_JSON ensures that listing templates respects the --json
 // output format.
 func TestTemplates_JSON(t *testing.T) {
-	t.Setenv("XDG_CONFIG_HOME", t.TempDir()) // ignore user-added
-	buf := piped(t)                          // gather output
+	_ = fromTempDirectory(t)
+
+	buf := piped(t) // gather output
 	cmd := NewTemplatesCmd(NewClientFactory(func() *fn.Client {
 		return fn.New()
 	}))
@@ -104,7 +106,8 @@ func TestTemplates_JSON(t *testing.T) {
 // TestTemplates_ByLanguage ensures that the output is correctly filtered
 // by language runtime when provided.
 func TestTemplates_ByLanguage(t *testing.T) {
-	t.Setenv("XDG_CONFIG_HOME", t.TempDir()) // ignore user-added
+	_ = fromTempDirectory(t)
+
 	cmd := NewTemplatesCmd(NewClientFactory(func() *fn.Client {
 		return fn.New()
 	}))
@@ -144,7 +147,8 @@ http`
 }
 
 func TestTemplates_ErrTemplateRepoDoesNotExist(t *testing.T) {
-	defer t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	_ = fromTempDirectory(t)
+
 	cmd := NewTemplatesCmd(NewClientFactory(func() *fn.Client {
 		return fn.New()
 	}))
@@ -155,7 +159,8 @@ func TestTemplates_ErrTemplateRepoDoesNotExist(t *testing.T) {
 }
 
 func TestTemplates_WrongRepositoryUrl(t *testing.T) {
-	defer t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	_ = fromTempDirectory(t)
+
 	cmd := NewTemplatesCmd(NewClientFactory(func() *fn.Client {
 		return fn.New()
 	}))

--- a/repositories_test.go
+++ b/repositories_test.go
@@ -18,7 +18,7 @@ import (
 // test.  Others do eist with specific test requirements that are mutually
 // exclusive, such as manifest differences, and are specified inline to their
 // requisite test.
-const RepositoriesTestRepo = "repository"
+const RepositoriesTestRepo = "repository.git"
 
 // TestRepositories_List ensures the base case of listing
 // repositories without error in the default scenario of builtin only.
@@ -69,7 +69,7 @@ func TestRepositories_Get(t *testing.T) {
 // TestRepositories_All ensures repos are returned from
 // .All accessor.  Tests both builtin and buitlin+extensible cases.
 func TestRepositories_All(t *testing.T) {
-	uri := TestRepoURI(RepositoriesTestRepo, t)
+	uri := ServeRepo(RepositoriesTestRepo, t)
 	root, rm := Mktemp(t)
 	defer rm()
 
@@ -99,15 +99,15 @@ func TestRepositories_All(t *testing.T) {
 	// Assert it now includes both builtin and extended
 	if len(repositories) != 2 ||
 		repositories[0].Name != fn.DefaultRepositoryName ||
-		repositories[1].Name != RepositoriesTestRepo {
+		repositories[1].Name != "repository" {
 		t.Fatal("Repositories list does not pass shallow repository membership check")
 	}
 }
 
 // TestRepositories_Add checks basic adding of a repository by URI.
 func TestRepositories_Add(t *testing.T) {
-	uri := TestRepoURI(RepositoriesTestRepo, t) // ./testdata/$RepositoriesTestRepo.git
-	root, rm := Mktemp(t)                       // create and cd to a temp dir, returning path.
+	uri := ServeRepo(RepositoriesTestRepo, t) // ./testdata/$RepositoriesTestRepo.git
+	root, rm := Mktemp(t)                     // create and cd to a temp dir, returning path.
 	defer rm()
 
 	// Instantiate the client using the current temp directory as the
@@ -144,7 +144,7 @@ func TestRepositories_AddDeafultName(t *testing.T) {
 	// repo meant to exemplify the simplest use case:  a repo with no metadata
 	// that simply contains templates, grouped by runtime.  It therefore does
 	// not have a manifest and the default name will therefore be the repo name
-	uri := TestRepoURI(RepositoriesTestRepo, t) // ./testdata/$RepositoriesTestRepo.git
+	uri := ServeRepo(RepositoriesTestRepo, t) // ./testdata/$RepositoriesTestRepo.git
 	root, rm := Mktemp(t)
 	defer rm()
 
@@ -156,7 +156,7 @@ func TestRepositories_AddDeafultName(t *testing.T) {
 	}
 
 	// The name returned should be the repo name
-	if name != RepositoriesTestRepo {
+	if name != "repository" {
 		t.Fatalf("expected returned name '%v', got '%v'", RepositoriesTestRepo, name)
 	}
 
@@ -165,7 +165,7 @@ func TestRepositories_AddDeafultName(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	expected := []string{"default", RepositoriesTestRepo}
+	expected := []string{"default", "repository"}
 	if diff := cmp.Diff(expected, rr); diff != "" {
 		t.Error("Repositories differed (-want, +got):", diff)
 	}
@@ -179,7 +179,7 @@ func TestRepositories_AddWithManifest(t *testing.T) {
 	// defines a custom language pack and makes full use of the manifest.yaml.
 	// The manifest.yaml is included which specifies things like custom templates
 	// location and (appropos to this test) a default name/
-	uri := TestRepoURI("repository-a", t) // ./testdata/repository-a.git
+	uri := ServeRepo("repository-a", t) // ./testdata/repository-a.git
 	root, rm := Mktemp(t)
 	defer rm()
 
@@ -210,7 +210,7 @@ func TestRepositories_AddWithManifest(t *testing.T) {
 // TestRepositories_AddExistingErrors ensures that adding a repository that
 // already exists yields an error.
 func TestRepositories_AddExistingErrors(t *testing.T) {
-	uri := TestRepoURI(RepositoriesTestRepo, t)
+	uri := ServeRepo(RepositoriesTestRepo, t)
 	root, rm := Mktemp(t) // create and cd to a temp dir, returning path.
 	defer rm()
 
@@ -244,7 +244,7 @@ func TestRepositories_AddExistingErrors(t *testing.T) {
 
 // TestRepositories_Rename ensures renaming a repository succeeds.
 func TestRepositories_Rename(t *testing.T) {
-	uri := TestRepoURI(RepositoriesTestRepo, t)
+	uri := ServeRepo(RepositoriesTestRepo, t)
 	root, rm := Mktemp(t) // create and cd to a temp dir, returning path.
 	defer rm()
 
@@ -278,8 +278,8 @@ func TestRepositories_Rename(t *testing.T) {
 // TestRepositories_Remove ensures that removing a repository by name
 // removes it from the list and FS.
 func TestRepositories_Remove(t *testing.T) {
-	uri := TestRepoURI(RepositoriesTestRepo, t) // ./testdata/repository.git
-	root, rm := Mktemp(t)                       // create and cd to a temp dir
+	uri := ServeRepo(RepositoriesTestRepo, t) // ./testdata/repository.git
+	root, rm := Mktemp(t)                     // create and cd to a temp dir
 	defer rm()
 
 	// Instantiate the client using the current temp directory as the
@@ -313,7 +313,7 @@ func TestRepositories_Remove(t *testing.T) {
 // TestRepositories_URL ensures that a repository populates its URL member
 // from the git repository's origin url (if it is a git repo and exists)
 func TestRepositories_URL(t *testing.T) {
-	uri := TestRepoURI(RepositoriesTestRepo, t)
+	uri := ServeRepo(RepositoriesTestRepo, t)
 	root, rm := Mktemp(t)
 	defer rm()
 

--- a/templates_test.go
+++ b/templates_test.go
@@ -163,7 +163,7 @@ func TestTemplates_Remote(t *testing.T) {
 	root := "testdata/testTemplatesRemote"
 	defer Using(t, root)()
 
-	url := TestRepoURI(RepositoriesTestRepo, t)
+	url := ServeRepo(RepositoriesTestRepo, t)
 
 	// Create a client which explicitly specifies the Git repo at URL
 	// rather than relying on the default internally builtin template repo
@@ -328,7 +328,7 @@ func TestTemplates_ModeRemote(t *testing.T) {
 	root := "testdata/testTemplates_ModeRemote"
 	defer Using(t, root)()
 
-	url := TestRepoURI(RepositoriesTestRepo, t)
+	url := ServeRepo(RepositoriesTestRepo, t)
 
 	client := fn.New(
 		fn.WithRegistry(TestRegistry),


### PR DESCRIPTION
- :broom: reset viper on most tests
- :broom: use t.Cleanup throughout
- :broom: use t.TempDir throughout
- :broom: use a clean XDG_CONFIG_HOME by default
- :broom: specify explicit name in create tests (t.TempDir yields dir name invalid for funtions)
- :broom: moves helpers to root_test
- :broom: git server helper expects `.git` suffix and returns full http url

General cleanup of tests, the impetus being that a temp directory for HOME for all tests is prerequisite to the forthcoming Global Config: Function Context.

/kind cleanup