### PR TITLE
feat: always pull base image for s2i builds

### DIFF
--- a/s2i/builder.go
+++ b/s2i/builder.go
@@ -265,7 +265,8 @@ func (b *Builder) Build(ctx context.Context, f fn.Function) (err error) {
 	}()
 
 	opts := types.ImageBuildOptions{
-		Tags: []string{f.Image},
+		Tags:       []string{f.Image},
+		PullParent: true,
 	}
 
 	resp, err := client.ImageBuild(ctx, pr, opts)


### PR DESCRIPTION
# Changes

- :gift: Always pull base image for `s2i` builds. This should ensure we do build with up-to-date image including security patches.

/kind enhancement
